### PR TITLE
Redis cache performance improvement

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -79,11 +79,10 @@ class RedisCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        $result = $this->redis->set($id, $data);
         if ($lifeTime > 0) {
-            $this->redis->expire($id, $lifeTime);
+            return $this->redis->setex($id, $lifeTime, $data);
         }
-        return $result;
+        return $this->redis->set($id, $data);
     }
 
     /**


### PR DESCRIPTION
> Reducing number of redis operations when using expiration time for setting data

This patch introduces `SETEX` command for setting data with expiration time. It will reduces number of operations for setting data with `lifeTime` and makes setting expiration time atomic.
