### PR TITLE
provide stats for file caches

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -117,12 +117,7 @@ abstract class FileCache extends CacheProvider
      */
     protected function doFlush()
     {
-        $pattern  = '/^.+\\' . $this->extension . '$/i';
-        $iterator = new \RecursiveDirectoryIterator($this->directory);
-        $iterator = new \RecursiveIteratorIterator($iterator);
-        $iterator = new \RegexIterator($iterator, $pattern);
-
-        foreach ($iterator as $name => $file) {
+        foreach ($this->getIterator() as $name => $file) {
             @unlink($name);
         }
 
@@ -134,6 +129,30 @@ abstract class FileCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        return null;
+        $usage = 0;
+        foreach ($this->getIterator() as $name => $file) {
+            $usage += $file->getSize();
+        }
+
+        $free = disk_free_space($this->directory);
+
+        return array(
+            Cache::STATS_HITS               => null,
+            Cache::STATS_MISSES             => null,
+            Cache::STATS_UPTIME             => null,
+            Cache::STATS_MEMORY_USAGE       => $usage,
+            Cache::STATS_MEMORY_AVAILABLE   => $free,
+        );
+    }
+
+    /**
+     * @return \Iterator
+     */
+    private function getIterator()
+    {
+        $pattern = '/^.+\\' . $this->extension . '$/i';
+        $iterator = new \RecursiveDirectoryIterator($this->directory);
+        $iterator = new \RecursiveIteratorIterator($iterator);
+        return new \RegexIterator($iterator, $pattern);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Cache;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\FilesystemCache;
 
 /**
@@ -18,7 +19,7 @@ class FilesystemCacheTest extends CacheTest
     {
         $dir = sys_get_temp_dir() . "/doctrine_cache_". uniqid();
         $this->assertFalse(is_dir($dir));
-        
+
         $this->driver = new FilesystemCache($dir);
         $this->assertTrue(is_dir($dir));
 
@@ -76,7 +77,11 @@ class FilesystemCacheTest extends CacheTest
         $cache = $this->_getCacheDriver();
         $stats = $cache->getStats();
 
-        $this->assertNull($stats);
+        $this->assertNull($stats[Cache::STATS_HITS]);
+        $this->assertNull($stats[Cache::STATS_MISSES]);
+        $this->assertNull($stats[Cache::STATS_UPTIME]);
+        $this->assertEquals(0, $stats[Cache::STATS_MEMORY_USAGE]);
+        $this->assertGreaterThan(0, $stats[Cache::STATS_MEMORY_AVAILABLE]);
     }
 
     public function tearDown()

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Cache;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\PhpFileCache;
 
 /**
@@ -98,7 +99,11 @@ class PhpFileCacheTest extends CacheTest
         $cache = $this->_getCacheDriver();
         $stats = $cache->getStats();
 
-        $this->assertNull($stats);
+        $this->assertNull($stats[Cache::STATS_HITS]);
+        $this->assertNull($stats[Cache::STATS_MISSES]);
+        $this->assertNull($stats[Cache::STATS_UPTIME]);
+        $this->assertEquals(0, $stats[Cache::STATS_MEMORY_USAGE]);
+        $this->assertGreaterThan(0, $stats[Cache::STATS_MEMORY_AVAILABLE]);
     }
 
     public function tearDown()


### PR DESCRIPTION
Filesystem caches can also provide at least a little bit of information to the user. So in order to get a better overview of my running cache I can use these.

So I added
- STATS_MEMORY_USAGE, which is the amount of bytes written into the cache files
- STATS_MEMORY_AVAILABLE, which is the amount of free bytes remaining on the disk or patition
