### PR TITLE
FilesystemCache should not use that many directories

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -97,7 +97,7 @@ abstract class FileCache extends CacheProvider
     protected function getFilename($id)
     {
         $hash = hash('sha256', $id);
-        $path = implode(str_split($hash, 16), DIRECTORY_SEPARATOR);
+        $path = implode(str_split($hash, 2), DIRECTORY_SEPARATOR);
         $path = $this->directory . DIRECTORY_SEPARATOR . $path;
         $id   = preg_replace('@[\\\/:"*?<>|]+@', '', $id);
 

--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -88,10 +88,11 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         $cache          = $this->driver;
         $method         = new \ReflectionMethod($cache, 'getFilename');
         $key            = 'item-key';
-        $expectedDir[]  = '84e0e2e893febb73';
-        $expectedDir[]  = '7a0fee0c89d53f4b';
-        $expectedDir[]  = 'b7fcb44c57cdf3d3';
-        $expectedDir[]  = '2ce7363f5d597760';
+        $expectedDir    = array(
+            '84', 'e0', 'e2', 'e8', '93', 'fe', 'bb', '73', '7a', '0f', 'ee',
+            '0c', '89', 'd5', '3f', '4b', 'b7', 'fc', 'b4', '4c', '57', 'cd',
+            'f3', 'd3', '2c', 'e7', '36', '3f', '5d', '59', '77', '60'
+        );
         $expectedDir    = implode(DIRECTORY_SEPARATOR, $expectedDir);
 
         $method->setAccessible(true);


### PR DESCRIPTION
... in order to have a manageable amount of items per directory. [See this blog post.](http://michaelandrews.typepad.com/the_technical_times/2009/10/creating-a-hashed-directory-structure.html)

When splitting the hash into four pieces, each containing 16 chars, with each 16 possible values this can lead to 16^16 (1.84467441e19) folders at each level. This might lead to an amount which goes far beyond filesystem limits. Even if a filesystem could handle that many items/folders, "stat operations such as listing files, following paths, or checking for the existence of a file" will be super slow! 