### PR TITLE
MongoDB cache provider

### DIFF
--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Common\Cache;
 
+use MongoBinData;
 use MongoCollection;
 use MongoDate;
 
@@ -91,7 +92,7 @@ class MongoDBCache extends CacheProvider
             return false;
         }
 
-        return unserialize($document[self::DATA_FIELD]);
+        return unserialize($document[self::DATA_FIELD]->bin);
     }
 
     /**
@@ -122,7 +123,7 @@ class MongoDBCache extends CacheProvider
             array('_id' => $id),
             array('$set' => array(
                 self::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
-                self::DATA_FIELD => serialize($data),
+                self::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
             )),
             array('upsert' => true, 'multiple' => false)
         );

--- a/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
@@ -31,6 +31,17 @@ class MongoDBCacheTest extends CacheTest
         }
     }
 
+    public function testSaveWithNonUtf8String()
+    {
+        // Invalid 2-octet sequence
+        $data = "\xc3\x28";
+
+        $cache = $this->_getCacheDriver();
+
+        $this->assertTrue($cache->save('key', $data));
+        $this->assertEquals($data, $cache->fetch('key'));
+    }
+
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();


### PR DESCRIPTION
This supersedes [#3](https://github.com/doctrine/cache/pull/3). I implemented support for lifetime, reporting successful write operations (if acknowledged writes are used at the driver level), and reporting what little stats MongoDB can provide. Some things to discuss before merging follow below.

---

@guilhermeblanco mentioned [here](https://github.com/doctrine/cache/pull/3#):

> For non-flat cache structures, like Mongo, Riak, etc, maybe we should consider the namespace to define the exchange to be used. In this specific situation, exchange would be the collection. I don't know the exact thoughts on this, but if we only consider flat schemas, then either we should not support complex drivers or we would support cache only tied to a single exchange (and this patch proposal would be ok). The last one would lead us to allow multiple caches to be defined for each possibility (what we do in ORM, but maybe refine even more).

The existing namespace cache key template (`DoctrineNamespaceCacheKey[%s]`) is quite verbose. For MongoDB, we're storing the cache key in the `_id` field, which a perfectly logical place (it's the only field that gets uniquely indexed by default). Using long values for an `_id` simply wastes index space. If we did split things up by collections, we'd have the ability to flush individual namespaces, and not have all namespaces share the same index server-side.

---

One other thing I discussed with @guilhermeblanco in IRC was the behavior when a document is queried for `fetch()` or `contains()`, but we must report it has a miss due to a lifetime expiration. He suggested having that read method issue a delete internally, since we'd have no means of garbage collection otherwise (MongoDB's [TTL indexing](http://docs.mongodb.org/manual/tutorial/expire-data/) doesn't really help us here). The filesystem cache, among other backends that don't support TTL, should likely follow suit. Do we want to implement this behavior across the board for consistency?
- [x] Add `delete()` calls if `fetch()` or `contains()` sees expired data

---

The base tests are a bit sparse, and don't have any support for TTL behavior. Should that be improved in this PR, or should we deal with it later?

---

All of the tests appear to be functional. In MongoDB's case (and other OO drivers), we could get away with mocking the classes and doing actual unit tests for the cache provider. I assume there's not much point to that, though?
