### PR TITLE
Reset namespace version

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -56,7 +56,8 @@ abstract class CacheProvider implements Cache
      */
     public function setNamespace($namespace)
     {
-        $this->namespace = (string) $namespace;
+        $this->namespace        = (string) $namespace;
+        $this->namespaceVersion = null;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -69,6 +69,31 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->contains('key1'));
     }
 
+    public function testDeleteAllNamespace()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $cache->setNamespace('ns1');
+        $this->assertFalse($cache->contains('key1'));
+        $cache->save('key1', 'test');
+        $this->assertTrue($cache->contains('key1'));
+
+        $cache->setNamespace('ns2');
+        $this->assertFalse($cache->contains('key1'));
+        $cache->save('key1', 'test');
+        $this->assertTrue($cache->contains('key1'));
+
+        $cache->setNamespace('ns1');
+        $this->assertTrue($cache->contains('key1'));
+        $cache->deleteAll();
+        $this->assertFalse($cache->contains('key1'));
+
+        $cache->setNamespace('ns2');
+        $this->assertTrue($cache->contains('key1'));
+        $cache->deleteAll();
+        $this->assertFalse($cache->contains('key1'));
+    }
+
     /**
      * @group DCOM-43
      */


### PR DESCRIPTION
If the namespace is changed after the version fetch it will keep the old version number..
Causing the cache to operate over a outdated namespace version..
