### PR TITLE
Cache namespace component

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,3 @@ Cache component extracted from the Doctrine Common project.
 
 * Added support for MongoDB as Cache Provider
 * Fix namespace version reset
-
-### v1.3
-
-* Added CacheNamespace component
-* Namespace (cache key prefix) is no logger added by default - **BC Break**

--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Cache component extracted from the Doctrine Common project.
 
 * Added support for MongoDB as Cache Provider
 * Fix namespace version reset
+
+### v1.3
+
+* Added CacheNamespace component
+* Namespace (cache key prefix) is no logger added by default - **BC Break**

--- a/lib/Doctrine/Common/Cache/CacheNamespace.php
+++ b/lib/Doctrine/Common/Cache/CacheNamespace.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for a cache namespace.
+ * 
+ * @since  1.3
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ */
+interface CacheNamespace
+{
+    /**
+     * Sets the namespace to prefix all cache keys with.
+     *
+     * @param string $namespace
+     *
+     * @return void
+     */
+    public function setNamespace($namespace);
+
+    /**
+     * Retrieves the namespace that prefixes all cache keys.
+     *
+     * @return string
+     */
+    public function getNamespace();
+
+    /**
+     * Prefixes the passed key with the configured namespace value.
+     *
+     * @param string $key The key to namespace.
+     *
+     * @return string The namespaced key.
+     */
+    public function getNamespacedKey($key);
+
+    /**
+     * @return integer
+     */
+    public function increment();
+}

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -34,6 +34,14 @@ abstract class CacheProvider implements Cache
     const DOCTRINE_NAMESPACE_CACHEKEY = 'DoctrineNamespaceCacheKey[%s]';
 
     /**
+     * @param \Doctrine\Common\Cache\CacheNamespace $cacheNamespace
+     */
+    public function __construct(CacheNamespace $cacheNamespace = null)
+    {
+        $this->cacheNamespace = $cacheNamespace ?: new DefaultCacheNamespace($this);
+    }
+
+    /**
      * @var \Doctrine\Common\Cache\CacheNamespace
      */
     private $cacheNamespace;
@@ -47,10 +55,6 @@ abstract class CacheProvider implements Cache
      */
     public function setNamespace($namespace)
     {
-        if ($this->cacheNamespace == null) {
-            $this->cacheNamespace = new DefaultCacheNamespace($this, self::DOCTRINE_NAMESPACE_CACHEKEY);
-        }
-
         $this->cacheNamespace->setNamespace($namespace);
     }
 
@@ -61,10 +65,6 @@ abstract class CacheProvider implements Cache
      */
     public function getNamespace()
     {
-        if ($this->cacheNamespace == null) {
-            return null;
-        }
-
         return $this->cacheNamespace->getNamespace();
     }
 
@@ -75,7 +75,7 @@ abstract class CacheProvider implements Cache
      */
     public function setCacheNamespace(CacheNamespace $cacheNamespace = null)
     {
-        $this->cacheNamespace = $cacheNamespace;
+        $this->cacheNamespace = $cacheNamespace ?: new NullCacheNamespace();
     }
 
     /**
@@ -119,11 +119,7 @@ abstract class CacheProvider implements Cache
      */
     public function fetch($id)
     {
-        if ($this->cacheNamespace) {
-            $id = $this->cacheNamespace->getNamespacedKey($id);
-        }
-
-        return $this->doFetch($id);
+        return $this->doFetch($this->cacheNamespace->getNamespacedKey($id));
     }
 
     /**
@@ -131,11 +127,7 @@ abstract class CacheProvider implements Cache
      */
     public function contains($id)
     {
-        if ($this->cacheNamespace) {
-            $id = $this->cacheNamespace->getNamespacedKey($id);
-        }
-
-        return $this->doContains($id);
+        return $this->doContains($this->cacheNamespace->getNamespacedKey($id));
     }
 
     /**
@@ -143,11 +135,7 @@ abstract class CacheProvider implements Cache
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        if ($this->cacheNamespace) {
-            $id = $this->cacheNamespace->getNamespacedKey($id);
-        }
-
-        return $this->doSave($id, $data, $lifeTime);
+        return $this->doSave($this->cacheNamespace->getNamespacedKey($id), $data, $lifeTime);
     }
 
     /**
@@ -155,11 +143,7 @@ abstract class CacheProvider implements Cache
      */
     public function delete($id)
     {
-        if ($this->cacheNamespace) {
-            $id = $this->cacheNamespace->getNamespacedKey($id);
-        }
-
-        return $this->doDelete($id);
+        return $this->doDelete($this->cacheNamespace->getNamespacedKey($id));
     }
 
     /**
@@ -187,10 +171,6 @@ abstract class CacheProvider implements Cache
      */
     public function deleteAll()
     {
-        if ($this->cacheNamespace === null) {
-            $this->cacheNamespace = new DefaultCacheNamespace($this, self::DOCTRINE_NAMESPACE_CACHEKEY);
-        }
-
         return $this->cacheNamespace->increment();
     }
 

--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -36,6 +36,17 @@ class CouchbaseCache extends CacheProvider
     private $couchbase;
 
     /**
+     * @param \Couchbase                                 $bucket
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
+     */
+    public function __construct(Couchbase $couchbase = null, CacheNamespace $cacheNamespace = null)
+    {
+        parent::__construct($cacheNamespace);
+
+        $this->couchbase = $couchbase;
+    }
+
+    /**
      * Sets the Couchbase instance to use.
      *
      * @param Couchbase $couchbase

--- a/lib/Doctrine/Common/Cache/DefaultCacheNamespace.php
+++ b/lib/Doctrine/Common/Cache/DefaultCacheNamespace.php
@@ -27,8 +27,6 @@ namespace Doctrine\Common\Cache;
  */
 class DefaultCacheNamespace implements CacheNamespace
 {
-    const DOCTRINE_NAMESPACE_CACHEKEY = 'doctrine_cache_ns_version_';
-
     /**
      * The namespace to prefix all cache keys with.
      *
@@ -58,7 +56,7 @@ class DefaultCacheNamespace implements CacheNamespace
     /**
      * @var string
      */
-    protected $format = '%s_%s_%s';
+    protected $format = '%s[%s][%s]';
 
     /**
      * @param \Doctrine\Common\Cache\CacheProvider $cache
@@ -111,7 +109,7 @@ class DefaultCacheNamespace implements CacheNamespace
     /**
      * Gets the format string for the namespaced cache keys.
      *
-     * @return type
+     * @return string
      */
     public function getFormat()
     {
@@ -125,7 +123,7 @@ class DefaultCacheNamespace implements CacheNamespace
     {
         $this->version   = null;
         $this->namespace = $namespace;
-        $this->cacheKey  = self::DOCTRINE_NAMESPACE_CACHEKEY . $this->namespace;
+        $this->cacheKey  = sprintf(CacheProvider::DOCTRINE_NAMESPACE_CACHEKEY, $this->namespace);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/DefaultCacheNamespace.php
+++ b/lib/Doctrine/Common/Cache/DefaultCacheNamespace.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * CacheNamespace compotible whit all doctrine cache drivers
+ *
+ * @since  1.3
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ */
+class DefaultCacheNamespace implements CacheNamespace
+{
+    const DOCTRINE_NAMESPACE_CACHEKEY = 'doctrine_cache_ns_version_';
+
+    /**
+     * The namespace to prefix all cache keys with.
+     *
+     * @var string
+     */
+    protected $namespace;
+
+    /**
+     * @var \Doctrine\Common\Cache\CacheProvider
+     */
+    protected $cache;
+
+    /**
+     * The namespace version.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * The key to store the namespace version.
+     *
+     * @var string
+     */
+    protected $cacheKey;
+
+    /**
+     * @var string
+     */
+    protected $format = '%s_%s_%s';
+
+    /**
+     * @param \Doctrine\Common\Cache\CacheProvider $cache
+     * @param string                               $namespace
+     */
+    public function __construct(CacheProvider $cache, $namespace = 'doctrine_cache')
+    {
+        $this->cache = $cache;
+
+        $this->setNamespace($namespace);
+    }
+
+    /**
+     * Sets the key to store the namespace version number.
+     *
+     * @param string $cacheKey
+     */
+    public function setCacheKey($cacheKey)
+    {
+        $this->cacheKey = $cacheKey;
+    }
+
+    /**
+     * Set the format string for the namespaced cache keys.
+     * It should contains The 3 directives : namespace, key and version number.
+     *
+     * <code>
+     *  <?php
+     *  $cacheNamespace->setNamespace('my_ns');
+     *  $cacheNamespace->setFormat('%s.%s.%s');
+     *
+     *  echo $cacheNamespace->getNamespacedKey('foo');
+     *  // my_ns.foo.1
+     *
+     *  $cacheNamespace->setNamespace('my_ns');
+     *  $cacheNamespace->setFormat('%s[%s][%s]');
+     * 
+     *  echo $cacheNamespace->getNamespacedKey('foo');
+     *  // my_ns[foo][1]
+     *  ?>
+     * </code>
+     *
+     * @param string $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * Gets the format string for the namespaced cache keys.
+     *
+     * @return type
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNamespace($namespace)
+    {
+        $this->version   = null;
+        $this->namespace = $namespace;
+        $this->cacheKey  = self::DOCTRINE_NAMESPACE_CACHEKEY . $this->namespace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespacedKey($key)
+    {
+        return sprintf($this->format, $this->namespace, $key, $this->version ?: $this->getVersion());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment()
+    {
+        $version = $this->getVersion() + 1;
+
+        if ($this->cache->saveUsingRealKey($this->cacheKey, $version)) {
+            $this->version = $version;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the current namespace version.
+     *
+     * @return string
+     */
+    protected function getVersion()
+    {
+        if ($this->version === null) {
+            $this->version = $this->fetchVersion();
+        }
+
+        return $this->version;
+    }
+
+    /**
+     * Fetchs the namespace version from cache.
+     *
+     * @return integer
+     */
+    protected function fetchVersion()
+    {
+        $version = $this->cache->fetchUsingRealKey($this->cacheKey);
+
+        if ($version === false) {
+            $version = 1;
+
+            $this->cache->saveUsingRealKey($this->cacheKey, $version);
+        }
+
+        return $version;
+    }
+}

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -44,13 +44,16 @@ abstract class FileCache extends CacheProvider
     /**
      * Constructor.
      *
-     * @param string      $directory The cache directory.
-     * @param string|null $extension The cache file extension.
+     * @param string                                     $directory      The cache directory.
+     * @param string|null                                $extension      The cache file extension.
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace The cache namespace.
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($directory, $extension = null)
+    public function __construct($directory, $extension = null, CacheNamespace $cacheNamespace = null)
     {
+        parent::__construct($cacheNamespace);
+
         if ( ! is_dir($directory) && ! @mkdir($directory, 0777, true)) {
             throw new \InvalidArgumentException(sprintf(
                 'The directory "%s" does not exist and could not be created.',
@@ -153,6 +156,7 @@ abstract class FileCache extends CacheProvider
         $pattern = '/^.+\\' . $this->extension . '$/i';
         $iterator = new \RecursiveDirectoryIterator($this->directory);
         $iterator = new \RecursiveIteratorIterator($iterator);
+
         return new \RegexIterator($iterator, $pattern);
     }
 }

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -40,6 +40,17 @@ class MemcacheCache extends CacheProvider
     private $memcache;
 
     /**
+     * @param \Memcache|null                             $memcache
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
+     */
+    public function __construct(Memcache $memcache = null, CacheNamespace $cacheNamespace = null)
+    {
+        parent::__construct($cacheNamespace);
+
+        $this->memcache = $memcache;
+    }
+
+    /**
      * Sets the memcache instance to use.
      *
      * @param Memcache $memcache
@@ -85,6 +96,7 @@ class MemcacheCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
         return $this->memcache->set($id, $data, 0, (int) $lifeTime);
     }
 
@@ -110,6 +122,7 @@ class MemcacheCache extends CacheProvider
     protected function doGetStats()
     {
         $stats = $this->memcache->getStats();
+
         return array(
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -40,6 +40,17 @@ class MemcachedCache extends CacheProvider
     private $memcached;
 
     /**
+     * @param \Memcached|null                            $memcached
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
+     */
+    public function __construct(Memcached $memcached = null, CacheNamespace $cacheNamespace = null)
+    {
+        parent::__construct($cacheNamespace);
+
+        $this->memcached = $memcached;
+    }
+
+    /**
      * Sets the memcache instance to use.
      *
      * @param Memcached $memcached
@@ -85,6 +96,7 @@ class MemcachedCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
         return $this->memcached->set($id, $data, (int) $lifeTime);
     }
 
@@ -113,6 +125,7 @@ class MemcachedCache extends CacheProvider
         $servers = $this->memcached->getServerList();
         $key     = $servers[0]['host'] . ':' . $servers[0]['port'];
         $stats   = $stats[$key];
+
         return array(
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],

--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -69,10 +69,14 @@ class MongoDBCache extends CacheProvider
      *
      * @see http://www.php.net/manual/en/mongo.readpreferences.php
      * @see http://www.php.net/manual/en/mongo.writeconcerns.php
-     * @param MongoCollection $collection
+     *
+     * @param \MongoCollection                           $collection
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
      */
-    public function __construct(MongoCollection $collection)
+    public function __construct(MongoCollection $collection, CacheNamespace $cacheNamespace = null)
     {
+        parent::__construct($cacheNamespace);
+
         $this->collection = $collection;
     }
 
@@ -89,6 +93,7 @@ class MongoDBCache extends CacheProvider
 
         if ($this->isExpired($document)) {
             $this->doDelete($id);
+
             return false;
         }
 
@@ -108,6 +113,7 @@ class MongoDBCache extends CacheProvider
 
         if ($this->isExpired($document)) {
             $this->doDelete($id);
+
             return false;
         }
 

--- a/lib/Doctrine/Common/Cache/NullCacheNamespace.php
+++ b/lib/Doctrine/Common/Cache/NullCacheNamespace.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * NullCacheNamespace does not support any namespace operation nor apply changes for the cache key.
+ *
+ * @since  1.3
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ */
+class NullCacheNamespace implements CacheNamespace
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNamespace($namespace)
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespacedKey($key)
+    {
+        return $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment()
+    {
+        throw new \BadMethodCallException(sprintf('"%s" cannot increment the cache namespace.', __CLASS__));
+    }
+}

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -36,6 +36,17 @@ class RedisCache extends CacheProvider
     private $redis;
 
     /**
+     * @param \Redis|null                                $redis
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
+     */
+    public function __construct(Redis $redis = null, CacheNamespace $cacheNamespace = null)
+    {
+        parent::__construct($cacheNamespace);
+
+        $this->redis = $redis;
+    }
+
+    /**
      * Sets the redis instance to use.
      *
      * @param Redis $redis
@@ -108,6 +119,7 @@ class RedisCache extends CacheProvider
     protected function doGetStats()
     {
         $info = $this->redis->info();
+
         return array(
             Cache::STATS_HITS   => false,
             Cache::STATS_MISSES => false,

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -20,7 +20,6 @@
 namespace Doctrine\Common\Cache;
 
 use Riak\Bucket;
-use Riak\Connection;
 use Riak\Input;
 use Riak\Exception;
 use Riak\Object;

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -43,10 +43,13 @@ class RiakCache extends CacheProvider
     /**
      * Sets the riak bucket instance to use.
      *
-     * @param \Riak\Bucket $bucket
+     * @param \Riak\Bucket                               $bucket
+     * @param \Doctrine\Common\Cache\CacheNamespace|null $cacheNamespace
      */
-    public function __construct(Bucket $bucket)
+    public function __construct(Bucket $bucket, CacheNamespace $cacheNamespace = null)
     {
+        parent::__construct($cacheNamespace);
+
         $this->bucket = $bucket;
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -40,8 +40,6 @@ class CouchbaseCacheTest extends CacheTest
 
     protected function _getCacheDriver()
     {
-        $driver = new CouchbaseCache();
-        $driver->setCouchbase($this->couchbase);
-        return $driver;
+        return new CouchbaseCache($this->couchbase);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/DefaultCacheNamespaceTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/DefaultCacheNamespaceTest.php
@@ -25,12 +25,12 @@ class DefaultCacheNamespaceTest extends DoctrineTestCase
         $this->cacheNamespace->setNamespace('foo');
 
         $this->assertEquals('foo', $this->cacheNamespace->getNamespace());
-        $this->assertEquals('foo_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('foo[key1][1]', $this->cacheNamespace->getNamespacedKey('key1'));
 
         $this->cacheNamespace->setNamespace('bar');
 
         $this->assertEquals('bar', $this->cacheNamespace->getNamespace());
-        $this->assertEquals('bar_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('bar[key1][1]', $this->cacheNamespace->getNamespacedKey('key1'));
     }
 
     public function testChangeFormat()
@@ -53,12 +53,12 @@ class DefaultCacheNamespaceTest extends DoctrineTestCase
     {
         $this->cacheNamespace->setNamespace('ns');
 
-        $this->assertEquals('ns_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
-        $this->assertEquals('ns_key2_1', $this->cacheNamespace->getNamespacedKey('key2'));
+        $this->assertEquals('ns[key1][1]', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('ns[key2][1]', $this->cacheNamespace->getNamespacedKey('key2'));
 
         $this->cacheNamespace->increment();
 
-        $this->assertEquals('ns_key1_2', $this->cacheNamespace->getNamespacedKey('key1'));
-        $this->assertEquals('ns_key2_2', $this->cacheNamespace->getNamespacedKey('key2'));
+        $this->assertEquals('ns[key1][2]', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('ns[key2][2]', $this->cacheNamespace->getNamespacedKey('key2'));
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/DefaultCacheNamespaceTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/DefaultCacheNamespaceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Doctrine\Tests\DoctrineTestCase;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\DefaultCacheNamespace;
+
+class DefaultCacheNamespaceTest extends DoctrineTestCase
+{
+    /**
+     * @var \Doctrine\Common\Cache\DefaultCacheNamespace
+     */
+    private $cacheNamespace;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cacheNamespace = new DefaultCacheNamespace(new ArrayCache());
+    }
+
+    public function testChangeNamespace()
+    {
+        $this->cacheNamespace->setNamespace('foo');
+
+        $this->assertEquals('foo', $this->cacheNamespace->getNamespace());
+        $this->assertEquals('foo_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
+
+        $this->cacheNamespace->setNamespace('bar');
+
+        $this->assertEquals('bar', $this->cacheNamespace->getNamespace());
+        $this->assertEquals('bar_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
+    }
+
+    public function testChangeFormat()
+    {
+        $this->cacheNamespace->setFormat('entry[%s][%s][%s]');
+        $this->cacheNamespace->setNamespace('ns');
+
+        $this->assertEquals('entry[%s][%s][%s]', $this->cacheNamespace->getFormat());
+        $this->assertEquals('entry[ns][key1][1]', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('entry[ns][key2][1]', $this->cacheNamespace->getNamespacedKey('key2'));
+
+        $this->cacheNamespace->setFormat('entry.%s.%s.%s');
+
+        $this->assertEquals('entry.%s.%s.%s', $this->cacheNamespace->getFormat());
+        $this->assertEquals('entry.ns.key1.1', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('entry.ns.key2.1', $this->cacheNamespace->getNamespacedKey('key2'));
+    }
+
+    public function testIncrementNamespaceVersion()
+    {
+        $this->cacheNamespace->setNamespace('ns');
+
+        $this->assertEquals('ns_key1_1', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('ns_key2_1', $this->cacheNamespace->getNamespacedKey('key2'));
+
+        $this->cacheNamespace->increment();
+
+        $this->assertEquals('ns_key1_2', $this->cacheNamespace->getNamespacedKey('key1'));
+        $this->assertEquals('ns_key2_2', $this->cacheNamespace->getNamespacedKey('key2'));
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -24,13 +24,10 @@ class FilesystemCacheTest extends BaseFileCacheTest
         $this->assertEquals('testing this out', $cache->fetch('test_key'));
 
         // access private methods
-        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
-        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
-
+        $getFilename = new \ReflectionMethod($cache, 'getFilename');
         $getFilename->setAccessible(true);
-        $getNamespacedId->setAccessible(true);
 
-        $id         = $getNamespacedId->invoke($cache, 'test_key');
+        $id         = 'test_key';
         $filename   = $getFilename->invoke($cache, $id);
 
         $data       = '';

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -27,7 +27,7 @@ class FilesystemCacheTest extends BaseFileCacheTest
         $getFilename = new \ReflectionMethod($cache, 'getFilename');
         $getFilename->setAccessible(true);
 
-        $id         = 'test_key';
+        $id         = $cache->getCacheNamespace()->getNamespacedKey('test_key');
         $filename   = $getFilename->invoke($cache, $id);
 
         $data       = '';

--- a/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
@@ -47,8 +47,6 @@ class MemcacheCacheTest extends CacheTest
 
     protected function _getCacheDriver()
     {
-        $driver = new MemcacheCache();
-        $driver->setMemcache($this->memcache);
-        return $driver;
+        return new MemcacheCache($this->memcache);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
@@ -49,8 +49,6 @@ class MemcachedCacheTest extends CacheTest
 
     protected function _getCacheDriver()
     {
-        $driver = new MemcachedCache();
-        $driver->setMemcached($this->memcached);
-        return $driver;
+        return new MemcachedCache($this->memcached);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -28,7 +28,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
 
         $getFilename->setAccessible(true);
 
-        $id     = 'test_key';
+        $id     = $cache->getCacheNamespace()->getNamespacedKey('test_key');
         $path   = $getFilename->invoke($cache, $id);
         $value  = include $path;
 

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -24,13 +24,11 @@ class PhpFileCacheTest extends BaseFileCacheTest
         $this->assertEquals('testing this out', $cache->fetch('test_key'));
 
         // access private methods
-        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
-        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
+        $getFilename = new \ReflectionMethod($cache, 'getFilename');
 
         $getFilename->setAccessible(true);
-        $getNamespacedId->setAccessible(true);
 
-        $id     = $getNamespacedId->invoke($cache, 'test_key');
+        $id     = 'test_key';
         $path   = $getFilename->invoke($cache, $id);
         $value  = include $path;
 

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -23,8 +23,6 @@ class RedisCacheTest extends CacheTest
 
     protected function _getCacheDriver()
     {
-        $driver = new RedisCache();
-        $driver->setRedis($this->_redis);
-        return $driver;
+        return new RedisCache($this->_redis);
     }
 }


### PR DESCRIPTION
It requires a BC break..

The namespace is no logger added by default, 
it means that by default entries are stored without any prefix.