### PR TITLE
Added multi get Interface and some basic implementations

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -75,6 +75,14 @@ class ApcCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
+    protected function doFetchMultiple(array $keys)
+    {
+        return apc_fetch($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doGetStats()
     {
         $info = apc_cache_info();

--- a/lib/Doctrine/Common/Cache/CacheMultiGet.php
+++ b/lib/Doctrine/Common/Cache/CacheMultiGet.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for cache drivers that allows to get many itmes at once.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+interface CacheMultiGet extends Cache
+{
+
+    /**
+     * Returns an assocaitive array of values for keys is found in cache.
+     *
+     * @param array $keys Array of keys to retrieve from chache
+     * @return array Array of values at the specified keys.
+     */
+    function fetchMultiple(array $keys);
+
+}

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -72,6 +72,14 @@ class MemcachedCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
+    protected function doFetchMultiple(array $keys)
+    {
+        return $this->memcached->getMulti($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doContains($id)
     {
         return (false !== $this->memcached->get($id));

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -28,6 +28,20 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($cache->delete('key'));
         $this->assertFalse($cache->contains('key'));
     }
+    
+    public function testFetchMulti()
+    {
+        $cache = $this->_getCacheDriver();
+
+        // Test saving some values, checking if it exists, and fetching it back with multiGet
+        $this->assertTrue($cache->save('key1', 'value1'));
+        $this->assertTrue($cache->save('key2', 'value2'));
+
+        $this->assertEquals(array('key1'=>'value1', 'key2'=>'value2'), $cache->fetchMultiple(array('key1', 'key2')));
+        $this->assertEquals(array('key1'=>'value1', 'key2'=>'value2'), $cache->fetchMultiple(array('key1', 'key3', 'key2')));
+        $this->assertEquals(array('key1'=>'value1', 'key2'=>'value2'), $cache->fetchMultiple(array('key1', 'key2', 'key3')));
+
+    }
 
     public function provideCrudValues()
     {


### PR DESCRIPTION
Added a multi-get interface that allows to benefit form vendors that offers a way to retrieve multiple items in one call (redis, memcached, apc...). 

I also added a default implementation into `CacheProvider` that fallbacks on `fetch()`.
I also added a multi-get implementation for memcache and apc.