### PR TITLE
Added flushAll and deleteAll to interface.

### DIFF
--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -84,6 +84,20 @@ interface Cache
     function delete($id);
 
     /**
+     * Deletes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully deleted, FALSE otherwise.
+     */
+    function deleteAll();
+
+    /**
+     * Flushes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     */
+    function flushAll();
+
+    /**
      * Retrieves cached information from the data store.
      *
      * The server's statistics array has the following values:


### PR DESCRIPTION
The flushAll and deleteAll methods are in the CacheProvider and are the only methods to flush data but are missing from the interface which means they can not be depended on.

doctrine/DoctrineCacheBundle#16
