### PR TITLE
Fixed race conditions in FilesystemCache

### DIFF
--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -104,9 +104,6 @@ class FilesystemCache extends FileCache
         $filename   = $this->getFilename($id);
         $filepath   = pathinfo($filename, PATHINFO_DIRNAME);
 
-        // Folder create and file save routine shamelessly copied from
-        // https://github.com/fabpot/Twig/blob/master/lib/Twig/Environment.php :: writeCacheFile
-        // Original code author: https://github.com/fabpot
         if (!is_dir($filepath)) {
             if (false === @mkdir($filepath, 0777, true) && !is_dir($filepath)) {
                 return false;


### PR DESCRIPTION
In our environment (presumably because of the NFS) under high load after deployment, a lot of E_WARNINGs are emitted  because of race condition in mkdir() used in the FileSystemCache::save.

Fortunately I've seen a very good solution for this problem in the Twig library: https://github.com/fabpot/Twig/blob/master/lib/Twig/Environment.php :: writeCacheFile

I have copied and slightly adapted the cache write routine from Twig library. Hopefully it is allowed, with proper appreciation.
