### PR TITLE
Fix lifetime calculation in Memcache and Memcached drivers.

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -82,9 +82,6 @@ class MemcacheCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        if ($lifeTime > 30 * 24 * 3600) {
-            $lifeTime = time() + $lifeTime;
-        }
         return $this->memcache->set($id, $data, 0, (int) $lifeTime);
     }
 

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -82,7 +82,7 @@ class MemcachedCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        if ($lifeTime > 30 * 24 * 3600) {
+        if ($lifeTime < 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
         return $this->memcached->set($id, $data, (int) $lifeTime);


### PR DESCRIPTION
I'm surprised, but doctrine cache has wrong calculation of lifetime for memcached driver - if lifetime is more than a month it adds current timestamp.

Fix this behavior - if lifetime is less than month then it's assumed a relative timestamp and added to current timestamp.
