### PR TITLE
Remove superflous isset check

### DIFF
--- a/lib/Doctrine/Common/Cache/ArrayCache.php
+++ b/lib/Doctrine/Common/Cache/ArrayCache.php
@@ -50,7 +50,7 @@ class ArrayCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return isset($this->data[$id]) || array_key_exists($id, $this->data);
+        return array_key_exists($id, $this->data);
     }
 
     /**


### PR DESCRIPTION
Remove the isset-check in the array cache because we just need the result of array_key_exists
