### PR TITLE
Interface normalization.

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -29,7 +29,7 @@ namespace Doctrine\Common\Cache;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
-abstract class CacheProvider implements Cache
+abstract class CacheProvider implements Cache, FlushableCache, NamespacedCache, ClearableCache
 {
     const DOCTRINE_NAMESPACE_CACHEKEY = 'DoctrineNamespaceCacheKey[%s]';
 

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -48,11 +48,7 @@ abstract class CacheProvider implements Cache, FlushableCache, NamespacedCache, 
     private $namespaceVersion;
 
     /**
-     * Sets the namespace to prefix all cache ids with.
-     *
-     * @param string $namespace
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function setNamespace($namespace)
     {
@@ -61,9 +57,7 @@ abstract class CacheProvider implements Cache, FlushableCache, NamespacedCache, 
     }
 
     /**
-     * Retrieves the namespace that prefixes all cache ids.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getNamespace()
     {
@@ -111,9 +105,7 @@ abstract class CacheProvider implements Cache, FlushableCache, NamespacedCache, 
     }
 
     /**
-     * Flushes all cache entries.
-     *
-     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     * {@inheritDoc}
      */
     public function flushAll()
     {
@@ -121,9 +113,7 @@ abstract class CacheProvider implements Cache, FlushableCache, NamespacedCache, 
     }
 
     /**
-     * Deletes all cache entries.
-     *
-     * @return boolean TRUE if the cache entries were successfully deleted, FALSE otherwise.
+     * {@inheritDoc}
      */
     public function deleteAll()
     {

--- a/lib/Doctrine/Common/Cache/ClearableCache.php
+++ b/lib/Doctrine/Common/Cache/ClearableCache.php
@@ -23,7 +23,7 @@ namespace Doctrine\Common\Cache;
  * Interface for cache that can be flushed.
  *
  * @link   www.doctrine-project.org
- * @since  2.0
+ * @since  1.4
  * @author Adirelle <adirelle@gmail.com>
  */
 interface ClearableCache extends Cache

--- a/lib/Doctrine/Common/Cache/ClearableCache.php
+++ b/lib/Doctrine/Common/Cache/ClearableCache.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for cache that can be flushed.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface ClearableCache extends Cache
+{
+    /**
+     * Deletes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully deleted, FALSE otherwise.
+     */
+    public function deleteAll();
+}

--- a/lib/Doctrine/Common/Cache/ClearableCache.php
+++ b/lib/Doctrine/Common/Cache/ClearableCache.php
@@ -24,12 +24,7 @@ namespace Doctrine\Common\Cache;
  *
  * @link   www.doctrine-project.org
  * @since  2.0
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author Jonathan Wage <jonwage@gmail.com>
- * @author Roman Borschel <roman@code-factory.org>
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Adirelle <adirelle@gmail.com>
  */
 interface ClearableCache extends Cache
 {

--- a/lib/Doctrine/Common/Cache/FlushableCache.php
+++ b/lib/Doctrine/Common/Cache/FlushableCache.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for cache that can be flushed.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface FlushableCache extends Cache
+{
+    /**
+     * Flushes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     */
+    public function flushAll();
+}

--- a/lib/Doctrine/Common/Cache/FlushableCache.php
+++ b/lib/Doctrine/Common/Cache/FlushableCache.php
@@ -24,12 +24,7 @@ namespace Doctrine\Common\Cache;
  *
  * @link   www.doctrine-project.org
  * @since  2.0
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author Jonathan Wage <jonwage@gmail.com>
- * @author Roman Borschel <roman@code-factory.org>
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Adirelle <adirelle@gmail.com>
  */
 interface FlushableCache extends Cache
 {

--- a/lib/Doctrine/Common/Cache/FlushableCache.php
+++ b/lib/Doctrine/Common/Cache/FlushableCache.php
@@ -23,7 +23,7 @@ namespace Doctrine\Common\Cache;
  * Interface for cache that can be flushed.
  *
  * @link   www.doctrine-project.org
- * @since  2.0
+ * @since  1.4
  * @author Adirelle <adirelle@gmail.com>
  */
 interface FlushableCache extends Cache

--- a/lib/Doctrine/Common/Cache/NamespacedCache.php
+++ b/lib/Doctrine/Common/Cache/NamespacedCache.php
@@ -24,12 +24,7 @@ namespace Doctrine\Common\Cache;
  *
  * @link   www.doctrine-project.org
  * @since  2.0
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author Jonathan Wage <jonwage@gmail.com>
- * @author Roman Borschel <roman@code-factory.org>
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Adirelle <adirelle@gmail.com>
  */
 interface NamespacedCache extends Cache
 {

--- a/lib/Doctrine/Common/Cache/NamespacedCache.php
+++ b/lib/Doctrine/Common/Cache/NamespacedCache.php
@@ -23,7 +23,7 @@ namespace Doctrine\Common\Cache;
  * Interface for caches with namespace.
  *
  * @link   www.doctrine-project.org
- * @since  2.0
+ * @since  1.4
  * @author Adirelle <adirelle@gmail.com>
  */
 interface NamespacedCache extends Cache

--- a/lib/Doctrine/Common/Cache/NamespacedCache.php
+++ b/lib/Doctrine/Common/Cache/NamespacedCache.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for caches with namespace.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface NamespacedCache extends Cache
+{
+    /**
+     * Sets the namespace to prefix all cache ids with.
+     *
+     * @param string $namespace
+     *
+     * @return void
+     */
+    public function setNamespace($namespace);
+
+    /**
+     * Retrieves the namespace that prefixes all cache ids.
+     *
+     * @return string
+     */
+    public function getNamespace();
+}


### PR DESCRIPTION
Although the CacheProvider provides several interesting capabilities, most are not available through the Cache interface. This PR simply declares new interfaces and CacheProvider as implementation of theses.

Note that FlushableCache could be implemented only by implementations that were actually able to flush all entries, instead of CacheProvider.
