### PR TITLE
Bugfix: Fully clearing cache on doFlush()

### DIFF
--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -71,7 +71,7 @@ class XcacheCache extends CacheProvider
     {
         $this->checkAuthorization();
 
-        xcache_clear_cache(XC_TYPE_VAR, 0);
+        xcache_clear_cache(XC_TYPE_VAR);
 
         return true;
     }


### PR DESCRIPTION
Second parameter of xcache_clear_cache function indicates which chunk of cache to clear. Since doFlush() should clear entire cache the second parameter should be either omitted or set to -1 (http://xcache.lighttpd.net/wiki/XcacheApi)
