### PR TITLE
FilesystemCache sanitizes filenames before writing

### DIFF
--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -111,8 +111,10 @@ class FilesystemCache extends FileCache
         } elseif ( ! is_writable($filepath)) {
             return false;
         }
+        
+        $sanitizedFilename = preg_replace('/[^a-zA-Z0-9-_\.]/','-', basename($filename));
 
-        $tmpFile = tempnam($filepath, basename($filename));
+        $tmpFile = tempnam($filepath, $sanitizedFilename);
 
         if ((file_put_contents($tmpFile, $lifeTime . PHP_EOL . $data) !== false) && @rename($tmpFile, $filename)) {
             @chmod($filename, 0666 & ~umask());


### PR DESCRIPTION
Using the provided filename as the prefix for tempnam() lead to not being able to write the cache file if the filename had illegal characters. Characters other than letters, numbers, dashes, underscores, and full stops are now replaced with a dash.