### PR TITLE
Improve performance of doGetStats

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -77,7 +77,7 @@ class ApcCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        $info = apc_cache_info();
+        $info = apc_cache_info('', $limited = true);
         $sma  = apc_sma_info();
 
         // @TODO - Temporary fix @see https://github.com/krakjoe/apcu/pull/42


### PR DESCRIPTION
Hi,

by calling apc_cache_info without the limited parameter set, we are actually fetching ALL entries that are currently cached in APC. (http://php.net/manual/en/function.apc-cache-info.php)
As the code bellow does not need these entries for the statistics we should set the limited parameter to true to avoid performance issues if a large amount of APC-Cache has already been gathered.
