### PR TITLE
ArrayCache instead of ApcCache in ChainTest

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -37,7 +37,7 @@ class ChainCacheTest extends CacheTest
     public function testFetchPropagateToFastestCache()
     {
         $cache1 = new ArrayCache();
-        $cache2 = new ApcCache();
+        $cache2 = new ArrayCache();
 
         $cache2->save('bar', 'value');
 
@@ -54,7 +54,7 @@ class ChainCacheTest extends CacheTest
     public function testNamespaceIsPropagatedToAllProviders()
     {
         $cache1 = new ArrayCache();
-        $cache2 = new ApcCache();
+        $cache2 = new ArrayCache();
 
         $chainCache = new ChainCache(array($cache1, $cache2));
         $chainCache->setNamespace('bar');


### PR DESCRIPTION
- Because there is no APC requirement int composer, this test cannot use
  the ApcCache without checking the extension
- Intead of this one, let's use another ArrayCache to make tests pass
- Travis tests are not passing, with this change should pass
