### PR TITLE
Fix race condition in PhpFileCache

### DIFF
--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -100,26 +100,9 @@ class FilesystemCache extends FileCache
             $lifeTime = time() + $lifeTime;
         }
 
-        $data       = serialize($data);
-        $filename   = $this->getFilename($id);
-        $filepath   = pathinfo($filename, PATHINFO_DIRNAME);
+        $data      = serialize($data);
+        $filename  = $this->getFilename($id);
 
-        if ( ! is_dir($filepath)) {
-            if (false === @mkdir($filepath, 0777, true) && !is_dir($filepath)) {
-                return false;
-            }
-        } elseif ( ! is_writable($filepath)) {
-            return false;
-        }
-
-        $tmpFile = tempnam($filepath, basename($filename));
-
-        if ((file_put_contents($tmpFile, $lifeTime . PHP_EOL . $data) !== false) && @rename($tmpFile, $filename)) {
-            @chmod($filename, 0666 & ~umask());
-
-            return true;
-        }
-
-        return false;
+        return $this->writeFile($filename, $lifeTime . PHP_EOL . $data);
     }
 }

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -64,6 +64,10 @@ class PhpFileCache extends FileCache
         if ( ! is_file($filename)) {
             return false;
         }
+        
+        if ( ! is_readable($filename)) {
+            return false;
+        }
 
         $value = include $filename;
 

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -87,12 +87,7 @@ class PhpFileCache extends FileCache
             );
         }
 
-        $filename   = $this->getFilename($id);
-        $filepath   = pathinfo($filename, PATHINFO_DIRNAME);
-
-        if ( ! is_dir($filepath)) {
-            mkdir($filepath, 0777, true);
-        }
+        $filename  = $this->getFilename($id);
 
         $value = array(
             'lifetime'  => $lifeTime,
@@ -102,6 +97,6 @@ class PhpFileCache extends FileCache
         $value  = var_export($value, true);
         $code   = sprintf('<?php return %s;', $value);
 
-        return file_put_contents($filename, $code) !== false;
+        return $this->writeFile($filename, $code);
     }
 }


### PR DESCRIPTION
* Applied fix for possible race conditions from doctrine/cache#38 to `PhpFileCache` by extracting the code into the parent class to make sure both concrete caches create the cache file the same way
* Added a line to `unlink` a created temp file in case `rename` was not successful
* Removed duplicated code and made it more consistent. For example the `FilesystemCache` tried to create a missing path in `doSave` whereas `PhpFileCache` did not.

If you prefer two or three separate pull requests for this let me know.

Issue was originally reported in piwik/piwik#6873