### PR TITLE
Improved support for Redis serializing against HHVM

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -126,6 +126,9 @@ class RedisCache extends CacheProvider
      */
     protected function getSerializerValue()
     {
+        if (defined('HHVM_VERSION')) {
+            return Redis::SERIALIZER_PHP;
+        }
         return defined('Redis::SERIALIZER_IGBINARY') ? Redis::SERIALIZER_IGBINARY : Redis::SERIALIZER_PHP;
     }
 }


### PR DESCRIPTION
Removed support for Redis::SERIALIZER_IGBINARY for HHVM compability.

This fixes failing tests and functionality against HVVM with current master and previous versions. Tested with HHVM 3.3.0, Debian 7.6 and a running app top of Symfony 2.5.

Current cache driver implementation not works with HHVM, due to serialization problems:
https://travis-ci.org/doctrine/cache/jobs/46654706#L245-L358

Additional links for HHVM changes:
https://reviews.facebook.net/D31353
https://github.com/facebook/hhvm/pull/4623 https://github.com/facebook/hhvm/commit/c7cb8899a65b68984ca72aaa9fdbeb8236343535 
