### PR TITLE
Feature/mode spread hash setters

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -46,7 +46,7 @@ abstract class FileCache extends CacheProvider
      *
      * @var int
      */
-    protected $directory_mode = 0777;
+    protected $directoryMode = 0777;
 
     /**
      * The mode that files will be created with.  Null means the file will be created
@@ -54,7 +54,7 @@ abstract class FileCache extends CacheProvider
      *
      * @var int|null
      */
-    protected $file_mode;
+    protected $fileMode;
 
     /**
      * Constructor.
@@ -66,7 +66,7 @@ abstract class FileCache extends CacheProvider
      */
     public function __construct($directory, $extension = null)
     {
-        if ( ! is_dir($directory) && ! @mkdir($directory, $this->directory_mode, true)) {
+        if ( ! is_dir($directory) && ! @mkdir($directory, $this->directoryMode, true)) {
             throw new \InvalidArgumentException(sprintf(
                 'The directory "%s" does not exist and could not be created.',
                 $directory
@@ -90,7 +90,10 @@ abstract class FileCache extends CacheProvider
      */
     public function setDirectoryMode($mode)
     {
-        $this->directory_mode = $mode;
+        if ( ! is_int($mode)) {
+            throw new \InvalidArgumentException("You must specify permissions modes as an int");
+        }
+        $this->directoryMode = $mode;
     }
 
     /**
@@ -99,7 +102,10 @@ abstract class FileCache extends CacheProvider
      */
     public function setFileMode($mode)
     {
-        $this->file_mode = $mode;
+        if ( ! is_int($mode)) {
+            throw new \InvalidArgumentException("You must specify permissions modes as an int");
+        }
+        $this->fileMode = $mode;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -47,6 +47,15 @@ abstract class FileCache extends CacheProvider
      * @var int
      */
     protected $directoryMode = 0777;
+    
+    /**
+     * Cached objects are stored in directories.  These directory names are determined
+     * by splitting up the 32-char ID of the object into x parts.  If x=16 files will
+     * be two dirs deep (32/16=2).  If x=2 files will be eight dirs deep (32/2=16)
+     * 
+     * @var int
+     */
+    protected $directorySpreadChars = 16;
 
     /**
      * The mode that files will be created with.  Null means the file will be created
@@ -107,6 +116,22 @@ abstract class FileCache extends CacheProvider
         }
         $this->fileMode = $mode;
     }
+    
+    /**
+     * Cached objects are stored in directories.  These directory names are determined
+     * by splitting up the 32-char ID of the object into x parts.  
+     *   If x=16 files will be two dirs deep (32/16=2 ex: 1234567890123456/1234567890123456)
+     *   If x=2 files will be eight dirs deep (32/2=16 ex: 12/34/56/78/90/12/34/56/12/34/56/78/90/12/34/56)
+     * 
+     * @var int
+     */
+    public function setDirectorySpreadChars($chars)
+    {
+        if ( ! is_int($chars)) {
+            throw new \InvalidArgumentException("You must specify directory spread chars as an int");
+        }
+        $this->directorySpreadChars = $chars;
+    }
 
     /**
      * Gets the cache directory.
@@ -136,7 +161,7 @@ abstract class FileCache extends CacheProvider
     protected function getFilename($id)
     {
         $hash = hash('sha256', $id);
-        $path = implode(str_split($hash, 16), DIRECTORY_SEPARATOR);
+        $path = implode(str_split($hash, $this->directorySpreadChars), DIRECTORY_SEPARATOR);
         $path = $this->directory . DIRECTORY_SEPARATOR . $path;
         $id   = preg_replace('@[\\\/:"*?<>|]+@', '', $id);
 

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -68,7 +68,7 @@ abstract class FileCache extends CacheProvider
      * 
      * @var int
      */
-    protected $directorySpreadChars = 16;
+    protected $directorySpreadChars = 2;
 
     /**
      * The mode that files will be created with.  Null means the file will be created

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -66,6 +66,13 @@ abstract class FileCache extends CacheProvider
     protected $fileMode;
 
     /**
+     * The hash algorithm that is used to generate filenames
+     * 
+     * @var string
+     */
+    protected $hasher = 'sha256';
+
+    /**
      * Constructor.
      *
      * @param string      $directory The cache directory.
@@ -117,7 +124,17 @@ abstract class FileCache extends CacheProvider
         }
         $this->fileMode = $mode;
     }
-    
+
+    /**
+     * Sets the hashing algorithm that is used to generate filenames.
+     * 
+     * @param string $haserh
+     */
+    public function setHasher($hasher)
+    {
+        $this->hasher = $hasher;
+    }
+
     /**
      * Cached objects are stored in directories.  These directory names are determined
      * by splitting up the 32-char ID of the object into x parts.  
@@ -161,7 +178,7 @@ abstract class FileCache extends CacheProvider
      */
     protected function getFilename($id)
     {
-        $hash = hash('sha256', $id);
+        $hash = hash($this->hasher, $id);
         $path = implode(str_split($hash, $this->directorySpreadChars), DIRECTORY_SEPARATOR);
         $path = $this->directory . DIRECTORY_SEPARATOR . $path;
         $id   = preg_replace('@[\\\/:"*?<>|]+@', '', $id);

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -42,6 +42,21 @@ abstract class FileCache extends CacheProvider
     protected $extension;
 
     /**
+     * The mode that directories will be created with.
+     *
+     * @var int
+     */
+    protected $directory_mode = 0777;
+
+    /**
+     * The mode that files will be created with.  Null means the file will be created
+     * with the current umask.
+     *
+     * @var int|null
+     */
+    protected $file_mode;
+
+    /**
      * Constructor.
      *
      * @param string      $directory The cache directory.
@@ -51,7 +66,7 @@ abstract class FileCache extends CacheProvider
      */
     public function __construct($directory, $extension = null)
     {
-        if ( ! is_dir($directory) && ! @mkdir($directory, 0777, true)) {
+        if ( ! is_dir($directory) && ! @mkdir($directory, $this->directory_mode, true)) {
             throw new \InvalidArgumentException(sprintf(
                 'The directory "%s" does not exist and could not be created.',
                 $directory
@@ -67,6 +82,24 @@ abstract class FileCache extends CacheProvider
 
         $this->directory = realpath($directory);
         $this->extension = $extension ?: $this->extension;
+    }
+
+    /**
+     * Sets the mode that new directories will be created with.
+     * @param int $mode Mode, normally in octal (ex: 0755)
+     */
+    public function setDirectoryMode($mode)
+    {
+        $this->directory_mode = $mode;
+    }
+
+    /**
+     * Sets the mode that new files will be created with.
+     * @param int $mode Mode, normally in octal (ex: 0644)
+     */
+    public function setFileMode($mode)
+    {
+        $this->file_mode = $mode;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -105,9 +105,13 @@ class FilesystemCache extends FileCache
         $filepath   = pathinfo($filename, PATHINFO_DIRNAME);
 
         if ( ! is_dir($filepath)) {
-            mkdir($filepath, 0777, true);
+            mkdir($filepath, $this->directory_mode, true);
         }
 
-        return file_put_contents($filename, $lifeTime . PHP_EOL . $data) !== false;
+        $success = file_put_contents($filename, $lifeTime . PHP_EOL . $data) !== false;
+        if ($success && $this->file_mode !== null) {
+            chmod($filename, $this->file_mode);
+        }
+        return $success;
     }
 }

--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -105,12 +105,12 @@ class FilesystemCache extends FileCache
         $filepath   = pathinfo($filename, PATHINFO_DIRNAME);
 
         if ( ! is_dir($filepath)) {
-            mkdir($filepath, $this->directory_mode, true);
+            mkdir($filepath, $this->directoryMode, true);
         }
 
         $success = file_put_contents($filename, $lifeTime . PHP_EOL . $data) !== false;
-        if ($success && $this->file_mode !== null) {
-            chmod($filename, $this->file_mode);
+        if ($success && $this->fileMode !== null) {
+            chmod($filename, $this->fileMode);
         }
         return $success;
     }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -126,6 +126,10 @@ class RedisCache extends CacheProvider
      */
     protected function getSerializerValue()
     {
+        // Only PHP Serialization is supported in HHVM
+        if (defined('HHVM_VERSION')) {
+            return Redis::SERIALIZER_PHP;
+        }
         return defined('Redis::SERIALIZER_IGBINARY') ? Redis::SERIALIZER_IGBINARY : Redis::SERIALIZER_PHP;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -68,6 +68,79 @@ class FilesystemCacheTest extends BaseFileCacheTest
         $cache->setDirectoryMode('0775');
     }
 
+    public function testSetDirectorySpreadChars()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->setDirectorySpreadChars(3);
+
+        // Test save
+        $cache->save('test_key', 'testing this out', 10);
+
+        // access private methods
+        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
+        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
+
+        $getFilename->setAccessible(true);
+        $getNamespacedId->setAccessible(true);
+
+        $id         = $getNamespacedId->invoke($cache, 'test_key');
+        $filename   = $getFilename->invoke($cache, $id);
+
+        $path = trim(str_replace($this->directory, '', $filename), DIRECTORY_SEPARATOR);
+        $parts = explode(DIRECTORY_SEPARATOR, $path);
+        array_pop($parts);
+
+        $this->assertCount(22, $parts);
+    }
+
+    public function testSetHasher()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->setDirectorySpreadChars(2);
+
+        // Test save
+        $cache->save('test_key', 'testing this out', 10);
+
+        // access private methods
+        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
+        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
+
+        $getFilename->setAccessible(true);
+        $getNamespacedId->setAccessible(true);
+
+        $id         = $getNamespacedId->invoke($cache, 'test_key');
+        $filename   = $getFilename->invoke($cache, $id);
+
+        $path = trim(str_replace($this->directory, '', $filename), DIRECTORY_SEPARATOR);
+        $parts = explode(DIRECTORY_SEPARATOR, $path);
+        array_pop($parts);
+
+        // 2-char spread and sha256 hash produce 32 dirs deep
+        $this->assertCount(32, $parts);
+
+        $cache->setHasher('md5');
+
+        // Test save
+        $cache->save('test_key', 'testing this out', 10);
+
+        // access private methods
+        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
+        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
+
+        $getFilename->setAccessible(true);
+        $getNamespacedId->setAccessible(true);
+
+        $id         = $getNamespacedId->invoke($cache, 'test_key');
+        $filename   = $getFilename->invoke($cache, $id);
+
+        $path = trim(str_replace($this->directory, '', $filename), DIRECTORY_SEPARATOR);
+        $parts = explode(DIRECTORY_SEPARATOR, $path);
+        array_pop($parts);
+
+        // 2-char spread and md5 hash produce 32 dirs deep
+        $this->assertCount(16, $parts);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -56,6 +56,29 @@ class FilesystemCacheTest extends BaseFileCacheTest
         $this->assertFalse($cache->fetch('test_key'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetDirectoryModeAsNonIntThrows()
+    {
+        $cache = $this->_getCacheDriver();
+
+        // This may look right, but if it is cast to (int) it will be 
+        // (dec)755 instead of (oct)755, or 0755.  This is not what you want.
+        $cache->setDirectoryMode('0775');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetFileModeAsNonIntThrows()
+    {
+        $cache = $this->_getCacheDriver();
+
+        // String permissions are not allowed
+        $cache->setFileMode('ugo+rwx');
+    }
+
     public function testSetFileMode()
     {
         if (DIRECTORY_SEPARATOR !== '/') {


### PR DESCRIPTION
Here is the new PR based on https://github.com/doctrine/cache/pull/30 including configurable hashing mechanism, number of directory spread characters and file permissions.

Note that using SHA1 is causing one of my busy applications to fail in production due to a lack of inodes.  This is because there are so many directories created.  We are using this in production to overcome the issue:

```
$cache->setHasher('md5');
$cache->setDirectorySpreadChars(4);
```

This way we can balance the number of subdirs (4 deep max), with the number of files in each dir (10000 max, although much less in practice).