### PR TITLE
Reduce memory usage in SQLite3 cache

### DIFF
--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -179,7 +179,7 @@ class SQLite3Cache extends CacheProvider
 
         $statement->bindValue(':id', $id, SQLITE3_TEXT);
 
-        $item = $statement->execute()->fetchArray();
+        $item = $statement->execute()->fetchArray(SQLITE3_ASSOC);
 
         if ($item === false) {
             return null;


### PR DESCRIPTION
Fetching data as array [1](http://www.php.net/manual/en/sqlite3result.fetcharray.php) use SQLITE3_BOTH mode by default.

Column number association is not used anywhere in the SQLite3 cache driver, but only column name.

On large data, we can improved a bit the memory usage.

Don't forget also the https://github.com/doctrine/cache/pull/62 that is really necessary to prove that this driver is operational.
I recommand also to fixed all others binding values to avoid confusion and error.
