### PR TITLE
Unit test to solve original PR#62

### DIFF
--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -113,7 +113,7 @@ class SQLite3Cache extends CacheProvider
         ));
 
         $statement->bindValue(':id', $id);
-        $statement->bindValue(':data', serialize($data));
+        $statement->bindValue(':data', serialize($data), SQLITE3_BLOB);
         $statement->bindValue(':expire', $lifeTime > 0 ? time() + $lifeTime : null);
 
         return $statement->execute() instanceof SQLite3Result;

--- a/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
@@ -22,12 +22,35 @@ class SQLite3Test extends CacheTest
 
     protected function tearDown()
     {
+        $this->sqlite = null;  // DB must be closed before
         unlink($this->file);
     }
 
     public function testGetStats()
     {
         $this->assertNull($this->_getCacheDriver()->getStats());
+    }
+
+    public function testFetchSingle()
+    {
+        $id = uniqid('sqlite3_id_');
+
+        $data = $this->_getCacheDriver();
+
+        $this->_getCacheDriver()->save($id, $data, 30);
+
+        try {
+            $actual = $this->_getCacheDriver()->fetch($id);
+
+        } catch (\PHPUnit_Framework_Error $e) {
+            $this->fail('Unexpected exception has been raised. ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $data,
+            $actual,
+            'data saved and retrieved does not match.'
+        );
     }
 
     protected function _getCacheDriver()


### PR DESCRIPTION
Here is a unit to demonstrate issue that truncate data.

1 - I've took the SQLite3Cache as object sample, but we can pick any other objects.
2 - I've fixed the `tearDown()` method, to close the sqlite3 DB instance before to remove file (or we got denied permission)

Without fix, you should get something like 

    1) Doctrine\Tests\Common\Cache\SQLite3Test::testFetchSingle
    Unexpected exception has been raised. unserialize(): Error at offset 47 of 51 bytes

