### PR TITLE
Memcache::doContains incorrectly returns FALSE for some values

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -74,7 +74,11 @@ class MemcacheCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return (bool) $this->memcache->get($id);
+        $flags = null;
+        $this->memcache->get($id, $flags);
+        
+        //if memcache has changed the value of "flags", it means the value exists
+        return ($flags !== null);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
@@ -51,4 +51,34 @@ class MemcacheCacheTest extends CacheTest
         $driver->setMemcache($this->memcache);
         return $driver;
     }
+    
+    /**
+     * The following values get converted to FALSE if you cast them to a boolean.
+     * @see http://php.net/manual/en/types.comparisons.php
+     */
+    public function falseCastedValuesProvider()
+    {
+        return array(
+            array(false),
+            array(null),
+            array(array()),
+            array('0'),
+            array(0),
+            array(0.0),
+            array('')
+        );
+    }
+    
+    /**
+     * Check to see that, even if the user saves a value in memcache that can be interpreted as false,
+     * memcache will still recognize that it's there.
+     * @dataProvider falseCastedValuesProvider
+     */
+    public function testFalseCastedValues($value)
+    {
+        $cache = $this->_getCacheDriver();
+        
+        $this->assertTrue($cache->save('key', $value));
+        $this->assertTrue($cache->contains('key'));
+    }
 }


### PR DESCRIPTION
If you save a value in memcache that results in FALSE when it's cast to a boolean, then `MemcacheCache::doContains()` will not work. This PR fixes that by checking if `memcache::get()` changed the value of its 2nd parameter ("flags"). If it did, it means the value surely exists.

Example: Let's say you save an empty array in memcache. Calling `MemcacheCache::doContains()` will call `memcache::get()` internally and cast the result to boolean. Since `(bool) array()` is FALSE in PHP, `doContains` will tell you that memcache doesn't have that value, even if it's actually there.

This applies to the following values:

- 0
- 0.0
- "0"
- ""
- array()
- FALSE
- NULL

I also added a Unit-Test to make sure the behaviour is correct.

PS: This is similar to [PR-127](https://github.com/doctrine/common/pull/127), but the solution is implemented differently.