### PR TITLE
Reduced number of subdirectories generated by FileCache

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -111,7 +111,7 @@ abstract class FileCache extends CacheProvider
     {
         return $this->directory
             . DIRECTORY_SEPARATOR
-            . implode(str_split(hash('sha256', $id), 2), DIRECTORY_SEPARATOR)
+            . implode(str_split(substr(hash('sha256', $id), 0, 8), 2), DIRECTORY_SEPARATOR)
             . DIRECTORY_SEPARATOR
             . preg_replace($this->disallowedCharacterPatterns, $this->replacementCharacters, $id)
             . $this->extension;

--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -94,15 +94,10 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testFilenameShouldCreateThePathWithFourSubDirectories()
     {
-        $cache          = $this->driver;
-        $method         = new \ReflectionMethod($cache, 'getFilename');
-        $key            = 'item-key';
-        $expectedDir    = array(
-            '84', 'e0', 'e2', 'e8', '93', 'fe', 'bb', '73', '7a', '0f', 'ee',
-            '0c', '89', 'd5', '3f', '4b', 'b7', 'fc', 'b4', '4c', '57', 'cd',
-            'f3', 'd3', '2c', 'e7', '36', '3f', '5d', '59', '77', '60'
-        );
-        $expectedDir    = implode(DIRECTORY_SEPARATOR, $expectedDir);
+        $cache       = $this->driver;
+        $method      = new \ReflectionMethod($cache, 'getFilename');
+        $key         = 'item-key';
+        $expectedDir = implode(DIRECTORY_SEPARATOR, array('84', 'e0', 'e2', 'e8'));
 
         $method->setAccessible(true);
 


### PR DESCRIPTION
Currently FileCache implementation generates 32 subdirectories for each cache entry. This is inefficient (FS), useless (every single file is going to be stored in its own subdirectory) and leads to quite hard to debug/detect bugs caused by max filepath length (260 chars on Windows). 