### PR TITLE
Improved PhpFileCache performance by removing useless stat calls

### DIFF
--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -42,6 +42,7 @@ class PhpFileCache extends FileCache
      */
     protected function doFetch($id)
     {
+        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
         $value = @include $this->getFilename($id);
 
         if (! isset($value['lifetime'])) {
@@ -60,6 +61,7 @@ class PhpFileCache extends FileCache
      */
     protected function doContains($id)
     {
+        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
         $value = @include $this->getFilename($id);
 
         if (! isset($value['lifetime'])) {

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -42,10 +42,9 @@ class PhpFileCache extends FileCache
      */
     protected function doFetch($id)
     {
-        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
-        $value = @include $this->getFilename($id);
+        $value = $this->includeFileForId($id);
 
-        if (! isset($value['lifetime'])) {
+        if (! $value) {
             return false;
         }
 
@@ -61,10 +60,9 @@ class PhpFileCache extends FileCache
      */
     protected function doContains($id)
     {
-        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
-        $value = @include $this->getFilename($id);
+        $value = $this->includeFileForId($id);
 
-        if (! isset($value['lifetime'])) {
+        if (! $value) {
             return false;
         }
 
@@ -99,5 +97,24 @@ class PhpFileCache extends FileCache
         $code   = sprintf('<?php return %s;', $value);
 
         return $this->writeFile($filename, $code);
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return array|false
+     */
+    private function includeFileForId($id)
+    {
+        $fileName = $this->getFilename($id);
+
+        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
+        $value = @include $fileName;
+
+        if (! isset($value['lifetime'])) {
+            return false;
+        }
+
+        return $value;
     }
 }

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -42,13 +42,11 @@ class PhpFileCache extends FileCache
      */
     protected function doFetch($id)
     {
-        $filename = $this->getFilename($id);
+        $value = @include $this->getFilename($id);
 
-        if ( ! is_file($filename)) {
+        if (! isset($value['lifetime'])) {
             return false;
         }
-
-        $value = include $filename;
 
         if ($value['lifetime'] !== 0 && $value['lifetime'] < time()) {
             return false;
@@ -62,17 +60,11 @@ class PhpFileCache extends FileCache
      */
     protected function doContains($id)
     {
-        $filename = $this->getFilename($id);
+        $value = @include $this->getFilename($id);
 
-        if ( ! is_file($filename)) {
+        if (! isset($value['lifetime'])) {
             return false;
         }
-        
-        if ( ! is_readable($filename)) {
-            return false;
-        }
-
-        $value = include $filename;
 
         return $value['lifetime'] === 0 || $value['lifetime'] > time();
     }


### PR DESCRIPTION
Not sure if it's relevant, but this makes the `PhpFileCache` actually usable in a context where OpCache is enabled.