### PR TITLE
Handle circular references in PhpFileCache

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -65,12 +65,17 @@ class PhpFileCacheTest extends BaseFileCacheTest
         $this->assertTrue($cache->contains('test_set_state'));
     }
 
-    public function testNotImplementsSetState()
+    public function testRedundantReferences()
     {
         $cache = $this->_getCacheDriver();
 
-        $this->setExpectedException('InvalidArgumentException');
-        $cache->save('test_not_set_state', new NotSetStateClass(array(1,2,3)));
+        $obj1 = new SetStateClass(null);
+
+        $obj2 = new SetStateClass($obj1);
+
+        $obj1->setValue($obj2);
+
+        $cache->save('test_redundant_references', $obj1);
     }
 
     public function testGetStats()
@@ -100,6 +105,10 @@ class NotSetStateClass
         $this->value = $value;
     }
 
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
     public function getValue()
     {
         return $this->value;


### PR DESCRIPTION
In our homemade framework we could not only used PhpFileCache because our class (which is almost the same as yours) does not handle circular references.

Here is the solution we decided to implement. With this new implementation of this class you could used PhpFileCache instead of FileCache in the whole project.
