### PR TITLE
Fix PHPDoc for doFetch return type

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -225,7 +225,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      *
      * @param string $id The id of the cache entry to fetch.
      *
-     * @return string|boolean The cached data or FALSE, if no cache entry exists for the given id.
+     * @return mixed|boolean The cached data or FALSE, if no cache entry exists for the given id.
      */
     abstract protected function doFetch($id);
 


### PR DESCRIPTION
Changed confusing string return type for doFetch, which *can* return string, but will generally return an object - as defined in [Cache::fetch](https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/Cache.php#L55)