### PR TITLE
Add test for object save/fetch

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -307,6 +307,30 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     }
 
     /**
+     * Check to see that objects are correctly serialized and unserialized by the cache
+     * provider.
+     */
+    public function testCachedObject()
+    {
+        $cache = $this->_getCacheDriver();
+        $obj = new \stdClass();
+        $obj->foo = "bar";
+        $obj2 = new \stdClass();
+        $obj2->bar = "foo";
+        $obj2->obj = $obj;
+        $obj->obj2 = $obj2;
+        $cache->save("obj", $obj);
+
+        $fetched = $cache->fetch("obj");
+
+        $this->assertInstanceOf("stdClass", $obj);
+        $this->assertInstanceOf("stdClass", $obj->obj2);
+        $this->assertInstanceOf("stdClass", $obj->obj2->obj);
+        $this->assertEquals("bar", $fetched->foo);
+        $this->assertEquals("foo", $fetched->obj2->bar);
+    }
+
+    /**
      * Return whether multiple cache providers share the same storage.
      *
      * This is used for skipping certain tests for shared storage behavior.

--- a/tests/travis/php.ini
+++ b/tests/travis/php.ini
@@ -1,6 +1,7 @@
 extension="mongo.so"
 extension="memcache.so"
 extension="memcached.so"
+extension="redis.so"
 
 apc.enabled=1
 apc.enable_cli=1


### PR DESCRIPTION
This test reveals failures in serializing/unserializing objects in the PredisCache driver.