### PR TITLE
Change CacheTest::testFetchMulti to deleteAll first

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -33,6 +33,8 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
+        $cache->deleteAll();
+
         // Test saving some values, checking if it exists, and fetching it back with multiGet
         $this->assertTrue($cache->save('key1', 'value1'));
         $this->assertTrue($cache->save('key2', 'value2'));


### PR DESCRIPTION
This prevents spurious failures when testing the same platform with multiple drivers.