### PR TITLE
Fix RedisCache::fetchMultiple to actually work

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -71,15 +71,7 @@ class RedisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        $returnValues = array();
-        $fetchedItems = $this->redis->mget($keys);
-        foreach ($keys as $key) {
-            if (isset($fetchedItems[$key])) {
-                $returnValues[$key] = $fetchedItems[$key];
-            }
-        }
-
-        return $returnValues;
+        return array_filter(array_combine($keys, $this->redis->mget($keys)));
     }
 
     /**


### PR DESCRIPTION
RedisCache::fetchMultiple was not working properly -- test was failing due to the method not joining keys.