### PR TITLE
Added session-based cache provider

### DIFF
--- a/lib/Doctrine/Common/Cache/SessionCache.php
+++ b/lib/Doctrine/Common/Cache/SessionCache.php
@@ -66,7 +66,11 @@ class SessionCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return isset($_SESSION[$id]);
+        if (!isset($_SESSION)) {
+            return false;
+        }
+
+        return isset($_SESSION[$id]) || array_key_exists($id, $_SESSION);
     }
 
     /**
@@ -74,6 +78,10 @@ class SessionCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
+        if (!isset($_SESSION)) {
+            return false;
+        }
+
         $_SESSION[$id] = serialize($data);
         return true;
     }
@@ -83,6 +91,10 @@ class SessionCache extends CacheProvider
      */
     protected function doDelete($id)
     {
+        if (!isset($_SESSION)) {
+            return false;
+        }
+
         unset($_SESSION[$id]);
         return true;
     }

--- a/lib/Doctrine/Common/Cache/SessionCache.php
+++ b/lib/Doctrine/Common/Cache/SessionCache.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Session cache provider.
+ *
+ * @author Rudolf Theunissen <rudolf.theunissen@gmail.com>
+ */
+class SessionCache extends CacheProvider
+{
+    /**
+     * @param boolean $start Whether a session should be started if a session
+     *                       has not already been started.
+     */
+    public function __construct($start = true)
+    {
+        if ($start && ! $this->sessionStarted()) {
+            session_start();
+        }
+    }
+
+    /**
+     * @return boolean true if a session is already started, false otherwise.
+     */
+    private function sessionStarted()
+    {
+        if (version_compare(phpversion(), "5.4.0", ">=")) {
+            return session_status() === PHP_SESSION_ACTIVE;
+        }
+
+        return session_id() !== "";
+    }
+
+     /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        if (isset($_SESSION[$id])) {
+            return unserialize($_SESSION[$id]);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        return isset($_SESSION[$id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        $_SESSION[$id] = serialize($data);
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        unset($_SESSION[$id]);
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        session_unset();
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        // Session doesn't provide any valuable stats
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/SessionCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SessionCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Doctrine\Common\Cache\SessionCache;
+
+class SessionCacheTest extends CacheTest
+{
+    protected function setUp()
+    {
+        @session_start();
+        parent::setUp();
+    }
+
+    protected function _getCacheDriver()
+    {
+        return new SessionCache(false);
+    }
+
+    public function testGetStats()
+    {
+        $cache = $this->_getCacheDriver();
+        $stats = $cache->getStats();
+
+        $this->assertNull($stats);
+    }
+
+    protected function isSharedStorage()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This branch adds a basic session-based cache provider. The use case I came across was to store an OAuth2 access token, where the default cache provider is the user session, but you can use a Doctrine Cache Provider instead. To make dependency injection easier, it would be nice to be able to accept a Doctrine Cache Provider, while preserving the default session-based storage.