### PR TITLE
Fix race condition in FileCache-based drivers.

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -64,7 +64,7 @@ abstract class FileCache extends CacheProvider
      */
     public function __construct($directory, $extension = '')
     {
-        if ( ! is_dir($directory) && ! @mkdir($directory, 0777, true)) {
+        if ( ! $this->createPathIfNeeded($directory)) {
             throw new \InvalidArgumentException(sprintf(
                 'The directory "%s" does not exist and could not be created.',
                 $directory


### PR DESCRIPTION
This fixes a race condition which occurs when the directory was created between the calls to `is_dir` and `mkdir` by checking `is_dir` again after `mkdir`. If `mkdir` failed but `is_dir` return true anyway, there is no problem.