### PR TITLE
Add .idea directory to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 vendor/
 build/
 phpunit.xml


### PR DESCRIPTION
Per title, prevents PHPStorm's metadata directory being seen by git.