### PR TITLE
Fix RedisCache::fetchMultiple if keys array is empty

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -71,6 +71,9 @@ class RedisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
+        if (empty($keys)) {
+            return array();
+        }
         return array_filter(array_combine($keys, $this->redis->mget($keys)));
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -30,6 +30,16 @@ class RedisCacheTest extends CacheTest
         $this->assertNotNull($stats[Cache::STATS_HITS]);
         $this->assertNotNull($stats[Cache::STATS_MISSES]);
     }
+    
+    public function testFetchMultiWithEmptyKeysArray()
+    {
+        $cache = $this->_getCacheDriver();
+        
+        $this->assertEquals(
+            array(),
+            $cache->fetchMultiple(array())
+        );
+    }
 
     protected function _getCacheDriver()
     {

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -35,8 +35,7 @@ class RedisCacheTest extends CacheTest
     {
         $cache = $this->_getCacheDriver();
         
-        $this->assertEquals(
-            array(),
+        $this->assertEmpty(
             $cache->fetchMultiple(array())
         );
     }


### PR DESCRIPTION
If provided with an empty array, Redis mget returns false and array_combine expects parameter 2 to be array.
Therefore we need to check if $keys is empty and return an empty array.