### PR TITLE
Fix CacheProvider::fetchMultiple if keys array is empty

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -83,6 +83,9 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function fetchMultiple(array $keys)
     {
+        if (empty($keys)) {
+            return array();
+        }
         // note: the array_combine() is in place to keep an association between our $keys and the $namespacedKeys
         $namespacedKeys = array_combine($keys, array_map(array($this, 'getNamespacedId'), $keys));
         $items          = $this->doFetchMultiple($namespacedKeys);

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -86,6 +86,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         if (empty($keys)) {
             return array();
         }
+        
         // note: the array_combine() is in place to keep an association between our $keys and the $namespacedKeys
         $namespacedKeys = array_combine($keys, array_map(array($this, 'getNamespacedId'), $keys));
         $items          = $this->doFetchMultiple($namespacedKeys);

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -80,7 +80,15 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             $cache->fetchMultiple(array('foo', 'bar'))
         );
     }
-
+    
+    public function testFetchMultiWithEmptyKeysArray()
+    {
+        $cache = $this->_getCacheDriver();
+        
+        $this->assertEmpty(
+            $cache->fetchMultiple(array())
+        );
+    }
 
     public function provideCrudValues()
     {


### PR DESCRIPTION
This is fixing some errors when we provide an empty array to CacheProvider::fetchMultiple :
- On PHP 5.3, Both parameters of array_combine should have at least 1 element.
- If we provide an empty array, Redis mget returns false and array_combine expects parameter 2 to be array.