### PR TITLE
No need to save the default namespace version

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -192,15 +192,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         }
 
         $namespaceCacheKey = $this->getNamespaceCacheKey();
-        $namespaceVersion = $this->doFetch($namespaceCacheKey);
-
-        if (false === $namespaceVersion) {
-            $namespaceVersion = 1;
-
-            $this->doSave($namespaceCacheKey, $namespaceVersion);
-        }
-
-        $this->namespaceVersion = $namespaceVersion;
+        $this->namespaceVersion = $this->doFetch($namespaceCacheKey) ?: 1;
 
         return $this->namespaceVersion;
     }

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -151,9 +151,13 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         $namespaceCacheKey = $this->getNamespaceCacheKey();
         $namespaceVersion  = $this->getNamespaceVersion() + 1;
 
-        $this->namespaceVersion = $namespaceVersion;
+        if ($this->doSave($namespaceCacheKey, $namespaceVersion)) {
+            $this->namespaceVersion = $namespaceVersion;
 
-        return $this->doSave($namespaceCacheKey, $namespaceVersion);
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
+{
+    public function testFetchMultiWillFilterNonRequestedKeys()
+    {
+        /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->getMockForAbstractClass(
+            'Doctrine\Common\Cache\CacheProvider',
+            array(),
+            '',
+            true,
+            true,
+            true,
+            array('doFetchMultiple')
+        );
+
+        $cache
+            ->expects($this->once())
+            ->method('doFetchMultiple')
+            ->will($this->returnValue(array(
+                '[foo][1]' => 'bar',
+                '[bar][1]' => 'baz',
+                '[baz][1]' => 'tab',
+            )));
+
+        $this->assertEquals(
+            array('foo' => 'bar', 'bar' => 'baz'),
+            $cache->fetchMultiple(array('foo', 'bar'))
+        );
+    }
+
+    public function testFailedDeleteAllDoesNotChangeNamespaceVersion()
+    {
+        /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->getMockForAbstractClass(
+            'Doctrine\Common\Cache\CacheProvider',
+            array(),
+            '',
+            true,
+            true,
+            true,
+            array('doFetch', 'doSave', 'doContains')
+        );
+
+        $cache
+            ->expects($this->once())
+            ->method('doFetch')
+            ->with('DoctrineNamespaceCacheKey[]')
+            ->will($this->returnValue(false));
+
+        // doSave is only called once from deleteAll as we do not need to persist the default version in getNamespaceVersion()
+        $cache
+            ->expects($this->once())
+            ->method('doSave')
+            ->with('DoctrineNamespaceCacheKey[]')
+            ->will($this->returnValue(false));
+
+        // After a failed deleteAll() the local namespace version is not increased (still 1). Otherwise all data written afterwards
+        // would be lost outside the current instance.
+        $cache
+            ->expects($this->once())
+            ->method('doContains')
+            ->with('[key][1]')
+            ->will($this->returnValue(true));
+
+        $this->assertFalse($cache->deleteAll(), 'deleteAll() returns false when saving the namespace version fails');
+        $cache->contains('key');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -53,34 +53,6 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         );
     }
 
-    public function testFetchMultiWillFilterNonRequestedKeys()
-    {
-        /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
-        $cache = $this->getMockForAbstractClass(
-            'Doctrine\Common\Cache\CacheProvider',
-            array(),
-            '',
-            true,
-            true,
-            true,
-            array('doFetchMultiple')
-        );
-
-        $cache
-            ->expects($this->once())
-            ->method('doFetchMultiple')
-            ->will($this->returnValue(array(
-                '[foo][1]' => 'bar',
-                '[bar][1]' => 'baz',
-                '[baz][1]' => 'tab',
-            )));
-
-        $this->assertEquals(
-            array('foo' => 'bar', 'bar' => 'baz'),
-            $cache->fetchMultiple(array('foo', 'bar'))
-        );
-    }
-    
     public function testFetchMultiWithEmptyKeysArray()
     {
         $cache = $this->_getCacheDriver();
@@ -361,7 +333,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertEquals("bar", $fetched["obj1"]->foo);
         $this->assertEquals("baz", $fetched["obj2"]->bar);
     }
-    
+
     /**
      * Return whether multiple cache providers share the same storage.
      *

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -70,9 +70,9 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             ->expects($this->once())
             ->method('doFetchMultiple')
             ->will($this->returnValue(array(
-                '[foo][]' => 'bar',
-                '[bar][]' => 'baz',
-                '[baz][]' => 'tab',
+                '[foo][1]' => 'bar',
+                '[bar][1]' => 'baz',
+                '[baz][1]' => 'tab',
             )));
 
         $this->assertEquals(

--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -147,7 +147,7 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         $driver = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
             array('doFetch', 'doContains', 'doSave'),
-            array(__DIR__ . '/../', '/' . basename(__FILE__))
+            array(__DIR__ . '/../', DIRECTORY_SEPARATOR . basename(__FILE__))
         );
 
         $doGetStats = new \ReflectionMethod($driver, 'doGetStats');

--- a/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
@@ -15,6 +15,10 @@ class SQLite3Test extends CacheTest
 
     protected function setUp()
     {
+        if ( ! extension_loaded('sqlite3')) {
+            $this->markTestSkipped('The ' . __CLASS__ .' requires the use of SQLite3');
+        }
+
         $this->file = tempnam(null, 'doctrine-cache-test-');
         unlink($this->file);
         $this->sqlite = new SQLite3($this->file);


### PR DESCRIPTION
1. The namepace version is increased in deleteAll() and also saved there. So when the version is still the default (1) there is no point in persisting that. This way we save space and unneeded workload.

2. do not update the cached namespace version when persistence failed. Otherwise all data written after a failed delete, will not be available later on.