### PR TITLE
Fix delete() and flushAll()

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -61,7 +61,8 @@ class ApcCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return apc_delete($id);
+        // apc_delete returns false if the id does not exist
+        return apc_delete($id) || !apc_exists($id);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -66,10 +66,13 @@ interface Cache
     /**
      * Puts data into the cache.
      *
+     * If a cache entry with the given id already exists, its data will be replaced.
+     *
      * @param string $id       The cache id.
      * @param mixed  $data     The cache entry/data.
-     * @param int    $lifeTime The cache lifetime.
-     *                         If != 0, sets a specific lifetime for this cache entry (0 => infinite lifeTime).
+     * @param int    $lifeTime The lifetime in number of seconds for this cache entry.
+     *                         If zero (the default), the entry never expires (although it may be deleted from the cache
+     *                         to make place for other entries).
      *
      * @return boolean TRUE if the entry was successfully stored in the cache, FALSE otherwise.
      */
@@ -81,6 +84,7 @@ interface Cache
      * @param string $id The cache id.
      *
      * @return boolean TRUE if the cache entry was successfully deleted, FALSE otherwise.
+     *                 Deleting a non-existing entry is considered successful.
      */
     public function delete($id);
 

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -137,7 +137,9 @@ abstract class FileCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return @unlink($this->getFilename($id));
+        $filename = $this->getFilename($id);
+
+        return @unlink($filename) || !file_exists($filename);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -153,7 +153,7 @@ abstract class FileCache extends CacheProvider
                 // if the directory is empty. If several caches share the same directory but with different file extensions,
                 // the other ones are not removed.
                 @rmdir($name);
-            } elseif ('' === $this->extension || strrpos($name, $this->extension) === (strlen($name) - strlen($this->extension))) {
+            } elseif ($this->isFilenameEndingWithExtension($name)) {
                 // If an extension is set, only remove files which end with the given extension.
                 // If no extension is set, we have no other choice than removing everything.
                 @unlink($name);
@@ -170,7 +170,7 @@ abstract class FileCache extends CacheProvider
     {
         $usage = 0;
         foreach ($this->getIterator() as $name => $file) {
-            if (!$file->isDir() && ('' === $this->extension || strrpos($name, $this->extension) === (strlen($name) - strlen($this->extension)))) {
+            if (!$file->isDir() && $this->isFilenameEndingWithExtension($name)) {
                 $usage += $file->getSize();
             }
         }
@@ -243,5 +243,15 @@ abstract class FileCache extends CacheProvider
     private function getIterator()
     {
         return new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+    }
+
+    /**
+     * @param string $name The filename
+     *
+     * @return bool
+     */
+    private function isFilenameEndingWithExtension($name)
+    {
+        return '' === $this->extension || strrpos($name, $this->extension) === (strlen($name) - strlen($this->extension));
     }
 }

--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -53,7 +53,7 @@ class FilesystemCache extends FileCache
         $resource = fopen($filename, "r");
 
         if (false !== ($line = fgets($resource))) {
-            $lifetime = (integer) $line;
+            $lifetime = (int) $line;
         }
 
         if ($lifetime !== 0 && $lifetime < time()) {
@@ -86,7 +86,7 @@ class FilesystemCache extends FileCache
         $resource = fopen($filename, "r");
 
         if (false !== ($line = fgets($resource))) {
-            $lifetime = (integer) $line;
+            $lifetime = (int) $line;
         }
 
         fclose($resource);

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -97,7 +97,8 @@ class MemcacheCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return $this->memcache->delete($id);
+        // Memcache::delete() returns false if entry does not exist
+        return $this->memcache->delete($id) || !$this->doContains($id);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -82,7 +82,7 @@ class MemcachedCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return (false !== $this->memcached->get($id));
+        return (false !== $this->memcached->get($id) || $this->memcached->getResultCode() !== Memcached::RES_NOTFOUND);
     }
 
     /**
@@ -101,7 +101,7 @@ class MemcachedCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return $this->memcached->delete($id);
+        return $this->memcached->delete($id) || $this->memcached->getResultCode() === Memcached::RES_NOTFOUND;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -170,8 +170,8 @@ class MongoDBCache extends CacheProvider
         return array(
             Cache::STATS_HITS => null,
             Cache::STATS_MISSES => null,
-            Cache::STATS_UPTIME => (isset($serverStatus['uptime']) ? (integer) $serverStatus['uptime'] : null),
-            Cache::STATS_MEMORY_USAGE => (isset($collStats['size']) ? (integer) $collStats['size'] : null),
+            Cache::STATS_UPTIME => (isset($serverStatus['uptime']) ? (int) $serverStatus['uptime'] : null),
+            Cache::STATS_MEMORY_USAGE => (isset($collStats['size']) ? (int) $collStats['size'] : null),
             Cache::STATS_MEMORY_AVAILABLE  => null,
         );
     }

--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -41,7 +41,7 @@ class MongoDBCache extends CacheProvider
      * cache entry should expire.
      *
      * With MongoDB 2.2+, entries can be automatically deleted by MongoDB by
-     * indexing this field wit the "expireAfterSeconds" option equal to zero.
+     * indexing this field with the "expireAfterSeconds" option equal to zero.
      * This will direct MongoDB to regularly query for and delete any entries
      * whose date is older than the current time. Entries without a date value
      * in this field will be ignored.
@@ -138,7 +138,7 @@ class MongoDBCache extends CacheProvider
     {
         $result = $this->collection->remove(array('_id' => $id));
 
-        return isset($result['n']) ? $result['n'] == 1 : true;
+        return isset($result['ok']) ? $result['ok'] == 1 : true;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -48,6 +48,7 @@ class PredisCache extends CacheProvider
 
         return array_filter(array_combine($keys, array_map('unserialize', $fetchedItems)));
     }
+
     /**
      * {@inheritdoc}
      */
@@ -76,7 +77,7 @@ class PredisCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return $this->client->del($id) > 0;
+        return $this->client->del($id) >= 0;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -99,7 +99,7 @@ class RedisCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return $this->redis->delete($id) > 0;
+        return $this->redis->delete($id) >= 0;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
@@ -31,6 +31,8 @@ abstract class BaseFileCacheTest extends CacheTest
                 @rmdir($file->getRealPath());
             }
         }
+
+        @rmdir($this->directory);
     }
 
     protected function isSharedStorage()

--- a/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
@@ -9,14 +9,27 @@ abstract class BaseFileCacheTest extends CacheTest
 {
     protected $directory;
 
-    public function setUp()
+    public function testFlushAllRemovesBalancingDirectories()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $this->assertTrue($cache->save('key1', 1));
+        $this->assertTrue($cache->save('key2', 2));
+        $this->assertTrue($cache->flushAll());
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+
+        $this->assertCount(0, $iterator);
+    }
+
+    protected function setUp()
     {
         do {
             $this->directory = sys_get_temp_dir() . '/doctrine_cache_'. uniqid();
         } while (file_exists($this->directory));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ( ! is_dir($this->directory)) {
             return;

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -74,6 +74,14 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         );
     }
 
+    public function testDeleteIsSuccessfulWhenKeyDoesNotExist()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $this->assertFalse($cache->contains('key'));
+        $this->assertTrue($cache->delete('key'));
+    }
+
     public function testDeleteAll()
     {
         $cache = $this->_getCacheDriver();
@@ -155,7 +163,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
          */
         $this->assertTrue($cache2->save('key2', 2));
 
-        /* Both providers have the same namespace version and can see entires
+        /* Both providers have the same namespace version and can see entries
          * set by each other.
          */
         $this->assertTrue($cache1->contains('key1'));

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -27,6 +27,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         // Test deleting a value
         $this->assertTrue($cache->delete('key'));
         $this->assertFalse($cache->contains('key'));
+        $this->assertFalse($cache->fetch('key'));
     }
 
     public function testFetchMulti()
@@ -276,7 +277,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
 
         $this->assertTrue($cache->save('key', $value));
         $this->assertTrue($cache->contains('key'));
-        $this->assertEquals($value, $cache->fetch('key'));
+        $this->assertSame($value, $cache->fetch('key'));
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -45,7 +45,7 @@ class FilesystemCacheTest extends BaseFileCacheTest
             $data .= $line;
         }
 
-        $this->assertNotEquals(0, $lifetime, "previous lifetime could not be loaded");
+        $this->assertNotEquals(0, $lifetime, 'previous lifetime could not be loaded');
 
         // update lifetime
         $lifetime = $lifetime - 20;

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -68,6 +68,38 @@ class FilesystemCacheTest extends BaseFileCacheTest
         $this->assertGreaterThan(0, $stats[Cache::STATS_MEMORY_AVAILABLE]);
     }
 
+    public function testCacheInSharedDirectoryIsPerExtension()
+    {
+        $cache1 = new FilesystemCache($this->directory, '.foo');
+        $cache2 = new FilesystemCache($this->directory, '.bar');
+
+        $this->assertTrue($cache1->save('key1', 11));
+        $this->assertTrue($cache1->save('key2', 12));
+
+        $this->assertTrue($cache2->save('key1', 21));
+        $this->assertTrue($cache2->save('key2', 22));
+
+        $this->assertSame(11, $cache1->fetch('key1'), 'Cache value must not be influenced by a different cache in the same directory but different extension');
+        $this->assertSame(12, $cache1->fetch('key2'));
+        $this->assertTrue($cache1->flushAll());
+        $this->assertFalse($cache1->fetch('key1'), 'flushAll() must delete all items with the current extension');
+        $this->assertFalse($cache1->fetch('key2'));
+
+        $this->assertSame(21, $cache2->fetch('key1'), 'flushAll() must not remove items with a different extension in a shared directory');
+        $this->assertSame(22, $cache2->fetch('key2'));
+    }
+
+    public function testFlushAllWithNoExtension()
+    {
+        $cache = new FilesystemCache($this->directory, '');
+
+        $this->assertTrue($cache->save('key1', 1));
+        $this->assertTrue($cache->save('key2', 2));
+        $this->assertTrue($cache->flushAll());
+        $this->assertFalse($cache->contains('key1'));
+        $this->assertFalse($cache->contains('key2'));
+    }
+
     protected function _getCacheDriver()
     {
         return new FilesystemCache($this->directory);

--- a/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
@@ -53,18 +53,4 @@ class MemcachedCacheTest extends CacheTest
         $driver->setMemcached($this->memcached);
         return $driver;
     }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @dataProvider falseCastedValuesProvider
-     */
-    public function testFalseCastedValues($value)
-    {
-        if (false === $value) {
-            $this->markTestIncomplete('Memcached currently doesn\'t support saving `false` values. ');
-        }
-
-        parent::testFalseCastedValues($value);
-    }
 }

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -13,18 +13,51 @@ class PhpFileCacheTest extends BaseFileCacheTest
     /**
      * {@inheritDoc}
      *
-     * @dataProvider falseCastedValuesProvider
-    */
-    public function testFalseCastedValues($value)
+     * @dataProvider provideDataToCache
+     */
+    public function testSetContainsFetchDelete($value)
     {
+        if (is_object($value) && ! method_exists($value, '__set_state')) {
+            $this->markTestSkipped('PhpFileCache only allows objects that implement __set_state() and fully support var_export()');
+        }
+
         if (0.0 === $value) {
             $cache = $this->_getCacheDriver();
 
             $this->assertTrue($cache->save('key', $value));
             $this->assertTrue($cache->contains('key'));
             $this->assertSame(0, $cache->fetch('key'), 'var_export exports float(0) as int(0) so we assert against 0 as integer');
+
+            $this->assertTrue($cache->delete('key'));
+            $this->assertFalse($cache->contains('key'));
+            $this->assertFalse($cache->fetch('key'));
         } else {
-            parent::testFalseCastedValues($value);
+            parent::testSetContainsFetchDelete($value);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @dataProvider provideDataToCache
+     */
+    public function testUpdateExistingEntry($value)
+    {
+        if (is_object($value) && ! method_exists($value, '__set_state')) {
+            $this->markTestSkipped('PhpFileCache only allows objects that implement __set_state() and fully support var_export()');
+        }
+
+        if (0.0 === $value) {
+            $cache = $this->_getCacheDriver();
+
+            $this->assertTrue($cache->save('key', 'old-value'));
+            $this->assertTrue($cache->contains('key'));
+
+            $this->assertTrue($cache->save('key', $value));
+            $this->assertTrue($cache->contains('key'));
+            $this->assertSame(0, $cache->fetch('key'), 'var_export exports float(0) as int(0) so we assert against 0 as integer');
+        } else {
+            parent::testUpdateExistingEntry($value);
         }
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -10,6 +10,24 @@ use Doctrine\Common\Cache\PhpFileCache;
  */
 class PhpFileCacheTest extends BaseFileCacheTest
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @dataProvider falseCastedValuesProvider
+    */
+    public function testFalseCastedValues($value)
+    {
+        if (0.0 === $value) {
+            $cache = $this->_getCacheDriver();
+
+            $this->assertTrue($cache->save('key', $value));
+            $this->assertTrue($cache->contains('key'));
+            $this->assertSame(0, $cache->fetch('key'), 'var_export exports float(0) as int(0) so we assert against 0 as integer');
+        } else {
+            parent::testFalseCastedValues($value);
+        }
+    }
+
     public function testLifetime()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
@@ -46,9 +46,9 @@ class PredisCacheTest extends CacheTest
     /**
      * {@inheritDoc}
      *
-     * @dataProvider falseCastedValuesProvider
+     * @dataProvider provideDataToCache
      */
-    public function testFalseCastedValues($value)
+    public function testSetContainsFetchDelete($value)
     {
         if (array() === $value) {
             $this->markTestIncomplete(
@@ -57,6 +57,23 @@ class PredisCacheTest extends CacheTest
             );
         }
 
-        parent::testFalseCastedValues($value);
+        parent::testSetContainsFetchDelete($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @dataProvider provideDataToCache
+     */
+    public function testUpdateExistingEntry($value)
+    {
+        if (array() === $value) {
+            $this->markTestIncomplete(
+                'Predis currently doesn\'t support saving empty array values. '
+                . 'See https://github.com/nrk/predis/issues/241'
+            );
+        }
+
+        parent::testUpdateExistingEntry($value);
     }
 }


### PR DESCRIPTION
1. fix delete() return value when file does not exist: it must return true even if the cache entry doesn't exist. False should only be returned in case of a failed delete. Since the outcome of deleting a non-existing entry is what we wanted anyway (the entry doesn't exist anymore), it should return true. But the filesystem cache returned false because `unlink` returns false if the file does not exist. This was also broken for some other cache drivers.
2. fix flushAll() and getStats() for file cache to ignore dot files and clean up balancing directories: before it also iterated over dot files `.` and `..` (if the extension is empty) trying to delete them, which of course failed, but was silenced. and intermediate directories for balancing were never removed. flushAll only removed the files but not the directories leaving alot of garbage behind.
3. tests were added for the above things and tests for the existing behavior that caches in a shared directory but different extensions do not influence each other.
4. fix Memcached handling of `false` as data
