### PR TITLE
[WIP] Namespaced cache decorator

### DIFF
--- a/lib/Doctrine/Common/Cache/ClearableCache.php
+++ b/lib/Doctrine/Common/Cache/ClearableCache.php
@@ -28,6 +28,8 @@ namespace Doctrine\Common\Cache;
  * @link   www.doctrine-project.org
  * @since  1.4
  * @author Adirelle <adirelle@gmail.com>
+ *
+ * @deprecated Use NamespacedCacheDecorator instead which makes sure that flushAll() only removes cache entries in the current namespace
  */
 interface ClearableCache
 {

--- a/lib/Doctrine/Common/Cache/NamespacedCacheDecorator.php
+++ b/lib/Doctrine/Common/Cache/NamespacedCacheDecorator.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Decorates another cache and adds a namespace to cache keys.
+ *
+ * This allows to avoid cache naming collisions when a global shared cache, like Redis, is used for different types of data
+ * or for multiple applications. Introducing namespaces for non-shared caches like ArrayCache and FileCache with its own directory
+ * or extension makes no sense.
+ *
+ * @author Tobias Schultze <http://tobion.de>
+ */
+class NamespacedCacheDecorator implements Cache, FlushableCache, ClearableCache, MultiGetCache
+{
+    /**
+     * @internal
+     */
+    const NAMESPACE_VERSION_KEY = 'DoctrineNamespaceVersion[%s]';
+
+    /**
+     * The namespace to prefix all cache ids with.
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * Under this cache id the current namespace version is saved.
+     *
+     * @var string
+     */
+    private $namespaceVersionKey;
+
+    /**
+     * @var Cache|FlushableCache|ClearableCache|MultiGetCache
+     */
+    private $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param string $namespace The namespace to prefix all cache ids with.
+     * @param Cache  $cache     The cache to decorate.
+     *
+     * @throws \InvalidArgumentException If the namespace is empty.
+     */
+    public function __construct($namespace, Cache $cache)
+    {
+        $this->namespace = (string) $namespace;
+
+        if ('' === $this->namespace) {
+            throw new \InvalidArgumentException('The namespace to prefix cache ids with must not be empty.');
+        }
+
+        $this->namespaceVersionKey = sprintf(self::NAMESPACE_VERSION_KEY, $this->namespace);
+        $this->cache = $cache;
+    }
+
+    /**
+     * Retrieves the namespace that prefixes all cache ids.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($id)
+    {
+        return $this->cache->fetch($this->getNamespacedId($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchMultiple(array $keys)
+    {
+        $namespacedKeys = array_map(array($this, 'getNamespacedId'), $keys);
+        $namespacedItems = $this->cache->fetchMultiple($namespacedKeys);
+        $keyAssociation = array_combine($namespacedKeys, $keys);
+        $items = array();
+
+        foreach ($namespacedItems as $namespacedKey => $value) {
+            $items[$keyAssociation[$namespacedKey]] = $value;
+        }
+
+        return $items;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($id)
+    {
+        return $this->cache->contains($this->getNamespacedId($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($id, $data, $lifeTime = 0)
+    {
+        return $this->cache->save($this->getNamespacedId($id), $data, $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($id)
+    {
+        return $this->cache->delete($this->getNamespacedId($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStats()
+    {
+        return $this->cache->getStats();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function flushAll()
+    {
+        return $this->cache->flushAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteAll()
+    {
+        $namespaceVersion = $this->getNamespaceVersion() + 1;
+
+        return $this->cache->save($this->namespaceVersionKey, $namespaceVersion);
+    }
+
+    /**
+     * Prefixes the passed id with the configured namespace value.
+     *
+     * @param string $id The id to namespace.
+     *
+     * @return string The namespaced id.
+     */
+    private function getNamespacedId($id)
+    {
+        $namespaceVersion = $this->getNamespaceVersion();
+
+        return sprintf('%s[%s][%s]', $this->namespace, $id, $namespaceVersion);
+    }
+
+    /**
+     * Returns the namespace version.
+     *
+     * @return int
+     */
+    private function getNamespaceVersion()
+    {
+        return $this->cache->fetch($this->namespaceVersionKey) ?: 1;
+    }
+}

--- a/lib/Doctrine/Common/Cache/NamespacedCacheDecorator.php
+++ b/lib/Doctrine/Common/Cache/NamespacedCacheDecorator.php
@@ -26,9 +26,13 @@ namespace Doctrine\Common\Cache;
  * or for multiple applications. Introducing namespaces for non-shared caches like ArrayCache and FileCache with its own directory
  * or extension makes no sense.
  *
+ * Decorating a cache with this namespace logic will also make sure that deleting all cache entries using `flushAll()` will
+ * only remove the cache entries of the given namespace and not everything. This way one application/library can delete
+ * all of its cache without interfering with the shared cache of another app/library.
+ *
  * @author Tobias Schultze <http://tobion.de>
  */
-class NamespacedCacheDecorator implements Cache, FlushableCache, ClearableCache, MultiGetCache
+class NamespacedCacheDecorator implements Cache, FlushableCache, MultiGetCache
 {
     /**
      * @internal
@@ -50,7 +54,7 @@ class NamespacedCacheDecorator implements Cache, FlushableCache, ClearableCache,
     private $namespaceVersionKey;
 
     /**
-     * @var Cache|FlushableCache|ClearableCache|MultiGetCache
+     * @var Cache|FlushableCache|MultiGetCache
      */
     private $cache;
 
@@ -145,14 +149,6 @@ class NamespacedCacheDecorator implements Cache, FlushableCache, ClearableCache,
      * {@inheritDoc}
      */
     public function flushAll()
-    {
-        return $this->cache->flushAll();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function deleteAll()
     {
         $namespaceVersion = $this->getNamespaceVersion() + 1;
 


### PR DESCRIPTION
The idea is to implement namespaces using a decorator. This makes much more sense than having namespaces built-into the generic CacheProvider because namspaces only make sense for shared caches. So non-shared caches like ArrayCache should not have namespace logic at all.

Also the need to add namespaces depends on the usage. If a developer uses a global cache like Redis but does not reuse it it many unrelated places (where he cannot ensure cache ids do not collide), there is no point in adding namespaces. This also has the benefit to not add the overhead when not needed. The current overhead comes from reading the namespace version on each fetch. So currently each fetch does two accesses. The version is cached in the CacheProvider to boost the performance, but that can obivously result in race conditions. So this is removed in the decorator.

Decorating a cache with this namespace logic will also make sure that deleting all cache entries using `flushAll()` will only remove the cache entries of the given namespace and not everything. This way one application/library can delete all of its cache without interfering with the shared cache of another app/library. This makes `ClearableCache::deleteAll` obsolete. Classes that use a cache should not have to care about `deleteAll` vs `flushAll`. They just want to delete the stuff. It's the task of the developer to make use of the namespace decorator when they have a global cache and different places where deletion can occur.

Todo
- [ ] Throw exception if decorated cache doesn't implement MultiGetCache or FlushableCache
- [ ] Add tests for decorator
- [ ] Deprecate `CacheProvider::setNamespace` and `CacheProvider::getNamespace`. In the next major version we can then remove namespacing from there and thus the cache providers that don't need it like ArrayCache will not by default inherit the namespace overhead.
- [ ] Update https://github.com/doctrine/DoctrineCacheBundle to use NamespacedCacheDecorator when a `namespace` config is used
- [ ] Update https://github.com/doctrine/doctrine2 to only use `flushAll` (or `deleteAll` if we want to settle on this name). This is mainly used in cache clear commands.
