### PR TITLE
fetchMultiple problems with null and falsey values

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -95,7 +95,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         // no internal array function supports this sort of mapping: needs to be iterative
         // this filters and combines keys in one pass
         foreach ($namespacedKeys as $requestedKey => $namespacedKey) {
-            if (isset($items[$namespacedKey])) {
+            if (isset($items[$namespacedKey]) || array_key_exists($namespacedKey, $items)) {
                 $foundItems[$requestedKey] = $items[$namespacedKey];
             }
         }

--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -45,17 +45,8 @@ class PredisCache extends CacheProvider
     protected function doFetchMultiple(array $keys)
     {
         $fetchedItems = call_user_func_array(array($this->client, 'mget'), $keys);
-        $foundItems = array();
-        $resultCounter = 0;
-
-        foreach ($keys AS $key) {
-            if ($fetchedItems[$resultCounter] !== null) {
-                $foundItems[$key] = unserialize($fetchedItems[$resultCounter]);
-            }
-            $resultCounter++;
-        }
-
-        return $foundItems;
+        
+        return array_map('unserialize', array_filter(array_combine($keys, $fetchedItems)));
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -45,7 +45,7 @@ class PredisCache extends CacheProvider
     protected function doFetchMultiple(array $keys)
     {
         $fetchedItems = call_user_func_array(array($this->client, 'mget'), $keys);
-        
+
         return array_map('unserialize', array_filter(array_combine($keys, $fetchedItems)));
     }
 

--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -45,8 +45,17 @@ class PredisCache extends CacheProvider
     protected function doFetchMultiple(array $keys)
     {
         $fetchedItems = call_user_func_array(array($this->client, 'mget'), $keys);
+        $foundItems = array();
+        $resultCounter = 0;
 
-        return array_filter(array_combine($keys, array_map('unserialize', $fetchedItems)));
+        foreach ($keys AS $key) {
+            if ($fetchedItems[$resultCounter] !== null) {
+                $foundItems[$key] = unserialize($fetchedItems[$resultCounter]);
+            }
+            $resultCounter++;
+        }
+
+        return $foundItems;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -71,7 +71,18 @@ class RedisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        return array_filter(array_combine($keys, $this->redis->mget($keys)));
+        $fetchedItems = $this->redis->mget($keys);
+        $foundItems = array();
+        $resultCounter = 0;
+
+        foreach ($keys AS $key) {
+            if ($fetchedItems[$resultCounter] !== false) {
+                $foundItems[$key] = $fetchedItems[$resultCounter];
+            }
+            $resultCounter++;
+        }
+
+        return $foundItems;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -72,17 +72,13 @@ class RedisCache extends CacheProvider
     protected function doFetchMultiple(array $keys)
     {
         $fetchedItems = $this->redis->mget($keys);
-        $foundItems = array();
-        $resultCounter = 0;
-
-        foreach ($keys AS $key) {
-            if ($fetchedItems[$resultCounter] !== false) {
-                $foundItems[$key] = $fetchedItems[$resultCounter];
+        
+        return array_filter(
+            array_combine($keys, $fetchedItems), 
+            function ($value) {
+                return $value !== false;
             }
-            $resultCounter++;
-        }
-
-        return $foundItems;
+        );
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -72,7 +72,7 @@ class RedisCache extends CacheProvider
     protected function doFetchMultiple(array $keys)
     {
         $fetchedItems = $this->redis->mget($keys);
-        
+
         return array_filter(
             array_combine($keys, $fetchedItems), 
             function ($value) {

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -96,6 +96,22 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         );
     }
 
+    public function testFetchMultiWithNull()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $cache->deleteAll();
+
+        // Test saving some values, checking if it exists, and fetching it back with multiGet
+        $this->assertTrue($cache->save('key1', 'value1'));
+        $this->assertTrue($cache->save('keyNull', null));
+
+        $this->assertEquals(
+            array('key1' => 'value1', 'keyNull' => null),
+            $cache->fetchMultiple(array('key1', 'keyNull'))
+        );
+    }
+
     public function provideDataToCache()
     {
         return array(

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -111,8 +111,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             'integer_zero' => 0,
             'string_empty' => ''
         );
-        foreach ($values AS $key => $value)
-        {
+        foreach ($values AS $key => $value) {
             $cache->save($key, $value);
         }
 

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -96,19 +96,29 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         );
     }
 
-    public function testFetchMultiWithNull()
+    public function testFetchMultiWithFalsey()
     {
         $cache = $this->_getCacheDriver();
 
         $cache->deleteAll();
 
-        // Test saving some values, checking if it exists, and fetching it back with multiGet
-        $this->assertTrue($cache->save('key1', 'value1'));
-        $this->assertTrue($cache->save('keyNull', null));
+        $values = array(
+            'string' => 'str',
+            'integer' => 1,
+            'boolean' => true,
+            'null' => null,
+            'array_empty' => array(),
+            'integer_zero' => 0,
+            'string_empty' => ''
+        );
+        foreach ($values AS $key => $value)
+        {
+            $cache->save($key, $value);
+        }
 
         $this->assertEquals(
-            array('key1' => 'value1', 'keyNull' => null),
-            $cache->fetchMultiple(array('key1', 'keyNull'))
+            $values,
+            $cache->fetchMultiple(array_keys($values))
         );
     }
 


### PR DESCRIPTION
If a null is stored in the cache, fetchMultiple will not return it as if it does not exist in the cache. It is returned internally by doFetchMultiple, but then unexpectedly filtered out by the isset check.

This applies the same approach used in ArrayCache to avoid calling array_key_exists unnecessarily.