### PR TITLE
Fix fetch multiple with false

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -211,8 +211,8 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     {
         $returnValues = array();
 
-        foreach ($keys as $index => $key) {
-            if (false !== ($item = $this->doFetch($key))) {
+        foreach ($keys as $key) {
+            if (false !== ($item = $this->doFetch($key)) || $this->doContains($key)) {
                 $returnValues[$key] = $item;
             }
         }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -71,14 +71,17 @@ class RedisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        $fetchedItems = $this->redis->mget($keys);
+        $fetchedItems = array_combine($keys, $this->redis->mget($keys));
 
-        return array_filter(
-            array_combine($keys, $fetchedItems),
-            function ($value) {
-                return $value !== false;
+        // Redis mget returns false for keys that do not exist. So we need to filter those out unless it's the real data.
+        $foundItems = array();
+        foreach ($fetchedItems as $key => $value) {
+            if (false !== $value || $this->redis->exists($key)) {
+                $foundItems[$key] = $value;
             }
-        );
+        }
+
+        return $foundItems;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
@@ -13,4 +13,9 @@ class ApcCacheTest extends CacheTest
     {
         return new ApcCache();
     }
+
+    public function testLifetime()
+    {
+        $this->markTestSkipped('The APC cache TTL is not working in a single process/request. See https://bugs.php.net/bug.php?id=58084');
+    }
 }

--- a/tests/Doctrine/Tests/Common/Cache/ArrayCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ArrayCacheTest.php
@@ -19,6 +19,11 @@ class ArrayCacheTest extends CacheTest
         $this->assertNull($stats);
     }
 
+    public function testLifetime()
+    {
+        $this->markTestSkipped('ArrayCache does not implement TTL currently.');
+    }
+
     protected function isSharedStorage()
     {
         return false;

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -119,6 +119,8 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         return array(
             'array' => array(array('one', 2, 3.01)),
             'string' => array('value'),
+            'string_invalid_utf8' => array("\xc3\x28"),
+            'string_null_byte' => array('with'."\0".'null char'),
             'integer' => array(1),
             'float' => array(1.5),
             'object' => array(new ArrayObject(array('one', 2, 3.01))),
@@ -131,7 +133,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             'string_zero' => array('0'),
             'integer_zero' => array(0),
             'float_zero' => array(0.0),
-            'string_empty' => array('')
+            'string_empty' => array(''),
         );
     }
 
@@ -139,6 +141,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
+        $cache->delete('key');
         $this->assertFalse($cache->contains('key'));
         $this->assertTrue($cache->delete('key'));
     }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -233,6 +233,30 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         );
     }
 
+    public function testLifetime()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('expire', 'value', 1);
+        $this->assertTrue($cache->contains('expire'), 'Data should not be expired yet');
+        sleep(2);
+        $this->assertFalse($cache->contains('expire'), 'Data should be expired');
+    }
+
+    public function testNoExpire()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('noexpire', 'value', 0);
+        sleep(1);
+        $this->assertTrue($cache->contains('noexpire'), 'Data with lifetime of zero should not expire');
+    }
+
+    public function testLongLifetime()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('longlifetime', 'value', 30 * 24 * 3600 + 1);
+        $this->assertTrue($cache->contains('longlifetime'), 'Data with lifetime > 30 days should be accepted');
+    }
+
     public function testDeleteAllAndNamespaceVersioningBetweenCaches()
     {
         if ( ! $this->isSharedStorage()) {

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -90,7 +90,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     public function testFetchMultiWithEmptyKeysArray()
     {
         $cache = $this->_getCacheDriver();
-        
+
         $this->assertEmpty(
             $cache->fetchMultiple(array())
         );
@@ -102,17 +102,10 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
 
         $cache->deleteAll();
 
-        $values = array(
-            'string' => 'str',
-            'integer' => 1,
-            'boolean' => true,
-            'null' => null,
-            'array_empty' => array(),
-            'integer_zero' => 0,
-            'string_empty' => ''
-        );
-        foreach ($values AS $key => $value) {
-            $cache->save($key, $value);
+        $values = $this->provideDataToCache();
+        foreach ($values as $key => $value) {
+            $cache->save($key, $value[0]);
+            $values[$key] = $value[0];
         }
 
         $this->assertEquals(

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -13,6 +13,11 @@ class ChainCacheTest extends CacheTest
         return new ChainCache(array(new ArrayCache()));
     }
 
+    public function testLifetime()
+    {
+        $this->markTestSkipped('The ChainCache test uses ArrayCache which does not implement TTL currently.');
+    }
+
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -21,22 +21,6 @@ class CouchbaseCacheTest extends CacheTest
         }
     }
 
-    public function testNoExpire()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('noexpire', 'value', 0);
-        sleep(1);
-        $this->assertTrue($cache->contains('noexpire'), 'Couchbase provider should support no-expire');
-    }
-
-    public function testLongLifetime()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('key', 'value', 30 * 24 * 3600 + 1);
-
-        $this->assertTrue($cache->contains('key'), 'Couchbase provider should support TTL > 30 days');
-    }
-
     protected function _getCacheDriver()
     {
         $driver = new CouchbaseCache();

--- a/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FilesystemCacheTest.php
@@ -10,52 +10,6 @@ use Doctrine\Common\Cache\FilesystemCache;
  */
 class FilesystemCacheTest extends BaseFileCacheTest
 {
-    public function testLifetime()
-    {
-        $cache = $this->_getCacheDriver();
-
-        // Test save
-        $cache->save('test_key', 'testing this out', 10);
-
-        // Test contains to test that save() worked
-        $this->assertTrue($cache->contains('test_key'));
-
-        // Test fetch
-        $this->assertEquals('testing this out', $cache->fetch('test_key'));
-
-        // access private methods
-        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
-        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
-
-        $getFilename->setAccessible(true);
-        $getNamespacedId->setAccessible(true);
-
-        $id         = $getNamespacedId->invoke($cache, 'test_key');
-        $filename   = $getFilename->invoke($cache, $id);
-
-        $data       = '';
-        $lifetime   = 0;
-        $resource   = fopen($filename, "r");
-
-        if (false !== ($line = fgets($resource))) {
-            $lifetime = (integer) $line;
-        }
-
-        while (false !== ($line = fgets($resource))) {
-            $data .= $line;
-        }
-
-        $this->assertNotEquals(0, $lifetime, 'previous lifetime could not be loaded');
-
-        // update lifetime
-        $lifetime = $lifetime - 20;
-        file_put_contents($filename, $lifetime . PHP_EOL . $data);
-
-        // test expired data
-        $this->assertFalse($cache->contains('test_key'));
-        $this->assertFalse($cache->fetch('test_key'));
-    }
-
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
@@ -42,21 +42,6 @@ class MemcacheCacheTest extends CacheTest
         return $ids;
     }
 
-    public function testNoExpire()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('noexpire', 'value', 0);
-        sleep(1);
-        $this->assertTrue($cache->contains('noexpire'), 'Memcache provider should support no-expire');
-    }
-
-    public function testLongLifetime()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('key', 'value', 30 * 24 * 3600 + 1);
-        $this->assertTrue($cache->contains('key'), 'Memcache provider should support TTL > 30 days');
-    }
-
     public function testGetMemcacheReturnsInstanceOfMemcache()
     {
         $this->assertInstanceOf('Memcache', $this->_getCacheDriver()->getMemcache());

--- a/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
@@ -44,21 +44,6 @@ class MemcachedCacheTest extends CacheTest
         return $ids;
     }
 
-    public function testNoExpire()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('noexpire', 'value', 0);
-        sleep(1);
-        $this->assertTrue($cache->contains('noexpire'), 'Memcache provider should support no-expire');
-    }
-
-    public function testLongLifetime()
-    {
-        $cache = $this->_getCacheDriver();
-        $cache->save('key', 'value', 30 * 24 * 3600 + 1);
-        $this->assertTrue($cache->contains('key'), 'Memcache provider should support TTL > 30 days');
-    }
-
     public function testGetMemcachedReturnsInstanceOfMemcached()
     {
         $this->assertInstanceOf('Memcached', $this->_getCacheDriver()->getMemcached());

--- a/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
@@ -34,17 +34,6 @@ class MongoDBCacheTest extends CacheTest
         }
     }
 
-    public function testSaveWithNonUtf8String()
-    {
-        // Invalid 2-octet sequence
-        $data = "\xc3\x28";
-
-        $cache = $this->_getCacheDriver();
-
-        $this->assertTrue($cache->save('key', $data));
-        $this->assertEquals($data, $cache->fetch('key'));
-    }
-
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -14,7 +14,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         $data = parent::provideDataToCache();
 
-        unset($data['object']); // PhpFileCache only allows objects that implement __set_state() and fully support var_export()
+        unset($data['object'], $data['object_recursive']); // PhpFileCache only allows objects that implement __set_state() and fully support var_export()
         unset($data['float_zero']); // var_export exports float(0) as int(0)
 
         return $data;
@@ -93,16 +93,6 @@ class PhpFileCacheTest extends BaseFileCacheTest
         $this->assertNull($stats[Cache::STATS_UPTIME]);
         $this->assertEquals(0, $stats[Cache::STATS_MEMORY_USAGE]);
         $this->assertGreaterThan(0, $stats[Cache::STATS_MEMORY_AVAILABLE]);
-    }
-
-    public function testCachedObject()
-    {
-        $this->markTestSkipped("PhpFileCache cannot handle objects that don't implement __set_state.");
-    }
-
-    public function testFetchMultipleObjects()
-    {
-        $this->markTestSkipped("PhpFileCache cannot handle objects that don't implement __set_state.");
     }
 
     protected function _getCacheDriver()

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -10,55 +10,14 @@ use Doctrine\Common\Cache\PhpFileCache;
  */
 class PhpFileCacheTest extends BaseFileCacheTest
 {
-    /**
-     * {@inheritDoc}
-     *
-     * @dataProvider provideDataToCache
-     */
-    public function testSetContainsFetchDelete($value)
+    public function provideDataToCache()
     {
-        if (is_object($value) && ! method_exists($value, '__set_state')) {
-            $this->markTestSkipped('PhpFileCache only allows objects that implement __set_state() and fully support var_export()');
-        }
+        $data = parent::provideDataToCache();
 
-        if (0.0 === $value) {
-            $cache = $this->_getCacheDriver();
+        unset($data['object']); // PhpFileCache only allows objects that implement __set_state() and fully support var_export()
+        unset($data['float_zero']); // var_export exports float(0) as int(0)
 
-            $this->assertTrue($cache->save('key', $value));
-            $this->assertTrue($cache->contains('key'));
-            $this->assertSame(0, $cache->fetch('key'), 'var_export exports float(0) as int(0) so we assert against 0 as integer');
-
-            $this->assertTrue($cache->delete('key'));
-            $this->assertFalse($cache->contains('key'));
-            $this->assertFalse($cache->fetch('key'));
-        } else {
-            parent::testSetContainsFetchDelete($value);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @dataProvider provideDataToCache
-     */
-    public function testUpdateExistingEntry($value)
-    {
-        if (is_object($value) && ! method_exists($value, '__set_state')) {
-            $this->markTestSkipped('PhpFileCache only allows objects that implement __set_state() and fully support var_export()');
-        }
-
-        if (0.0 === $value) {
-            $cache = $this->_getCacheDriver();
-
-            $this->assertTrue($cache->save('key', 'old-value'));
-            $this->assertTrue($cache->contains('key'));
-
-            $this->assertTrue($cache->save('key', $value));
-            $this->assertTrue($cache->contains('key'));
-            $this->assertSame(0, $cache->fetch('key'), 'var_export exports float(0) as int(0) so we assert against 0 as integer');
-        } else {
-            parent::testUpdateExistingEntry($value);
-        }
+        return $data;
     }
 
     public function testLifetime()

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -20,39 +20,6 @@ class PhpFileCacheTest extends BaseFileCacheTest
         return $data;
     }
 
-    public function testLifetime()
-    {
-        $cache = $this->_getCacheDriver();
-
-        // Test save
-        $cache->save('test_key', 'testing this out', 10);
-
-        // Test contains to test that save() worked
-        $this->assertTrue($cache->contains('test_key'));
-
-        // Test fetch
-        $this->assertEquals('testing this out', $cache->fetch('test_key'));
-
-        // access private methods
-        $getFilename        = new \ReflectionMethod($cache, 'getFilename');
-        $getNamespacedId    = new \ReflectionMethod($cache, 'getNamespacedId');
-
-        $getFilename->setAccessible(true);
-        $getNamespacedId->setAccessible(true);
-
-        $id     = $getNamespacedId->invoke($cache, 'test_key');
-        $path   = $getFilename->invoke($cache, $id);
-        $value  = include $path;
-
-        // update lifetime
-        $value['lifetime'] = $value['lifetime'] - 20;
-        file_put_contents($path, '<?php return unserialize(' . var_export(serialize($value), true) . ');');
-
-        // test expired data
-        $this->assertFalse($cache->contains('test_key'));
-        $this->assertFalse($cache->fetch('test_key'));
-    }
-
     public function testImplementsSetState()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
@@ -32,16 +32,6 @@ class SQLite3Test extends CacheTest
         $this->assertNull($this->_getCacheDriver()->getStats());
     }
 
-    public function testFetchSingle()
-    {
-        $id   = uniqid('sqlite3_id_');
-        $data = "\0"; // produces null bytes in serialized format
-
-        $this->_getCacheDriver()->save($id, $data, 30);
-
-        $this->assertEquals($data, $this->_getCacheDriver()->fetch($id));
-    }
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
When fixing https://github.com/doctrine/cache/pull/104/files#r43902042 I found that the `fetchMultiple` is broken, when the cached data is `false` which I fixed as well.