### PR TITLE
fix file cache naming under windows surpassing MAX_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ services:
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then pecl install riak-beta; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ./tests/travis/php.ini; fi;
-    - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then pecl config-set preferred_state beta; printf "yes\n" | pecl install apcu; fi;
+    - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/travis/php.ini; fi;
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ before_install:
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then pecl install riak-beta; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ./tests/travis/php.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu; fi;
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then phpenv config-rm xdebug.ini; pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/travis/php.ini; fi;
 
 install:
     - travis_retry composer install
 
 script:
-    - ./vendor/bin/phpunit -c ./tests/travis/phpunit.travis.xml -v --debug
+    - ./vendor/bin/phpunit -c ./tests/travis/phpunit.travis.xml -v
 
 after_script:
     - php vendor/bin/coveralls -v
@@ -41,3 +41,4 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: hhvm
+        - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ before_install:
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then pecl install riak-beta; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ./tests/travis/php.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu; fi;
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then phpenv config-rm xdebug.ini; pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/travis/php.ini; fi;
 
 install:
     - travis_retry composer install
 
 script:
-    - ./vendor/bin/phpunit -c ./tests/travis/phpunit.travis.xml -v
+    - ./vendor/bin/phpunit -c ./tests/travis/phpunit.travis.xml -v --debug
 
 after_script:
     - php vendor/bin/coveralls -v

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -115,10 +115,12 @@ abstract class FileCache extends CacheProvider
         $hash = hash('sha256', $id);
 
         // This ensures that the filename is unique and that there are no invalid chars in it.
-        if ('' === $id || strlen($id) > ((255 - strlen($this->extension)) / 2)) {
-            // Most filesystems have a limit of 255 chars for each path component. So if the id in hex representation
-            // plus the extension would surpass the limit, we use the hash instead. The prefix prevents collisions
-            // between the hash and bin2hex.
+        if ('' === $id || strlen($id) * 2 + strlen($this->extension) > 255 ||
+            (defined('PHP_WINDOWS_VERSION_BUILD') && strlen($this->directory) + 4 + strlen($id) * 2 + strlen($this->extension) > 259)) {
+            // Most filesystems have a limit of 255 chars for each path component. On Windows the the whole path is limited
+            // to 260 chars (including terminating null char). Using long UNC ("\\?\" prefix) does not work with the PHP API.
+            // So if the id in hex representation would surpass the limit, we use the hash instead. The prefix prevents
+            // collisions between the hash and bin2hex.
             $filename = '_' . $hash;
         } else {
             $filename = bin2hex($id);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,9 +5,6 @@
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
     backupGlobals="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     bootstrap="vendor/autoload.php"
 >
     <php>

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -233,6 +233,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             array("\0"),
             array(''),
             array(str_repeat('a', 300)), // long key
+            array(str_repeat('a', 113)),
         );
     }
 


### PR DESCRIPTION
I realised that doctrine annotation cache (which uses long cache keys) is failing in symfony under windows.
Its because in Windows the whole path is limited to 260 chars. See http://stackoverflow.com/questions/1880321/why-does-the-260-character-path-length-limit-exist-in-windows

Also fixed travis tests with apcu due to new releases of apcu for php 5 and 7.
