### PR TITLE
Avoid MongoCursorException with MongoCache

### DIFF
--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -119,14 +119,19 @@ class MongoDBCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        $result = $this->collection->update(
-            array('_id' => $id),
-            array('$set' => array(
-                self::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
-                self::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
-            )),
-            array('upsert' => true, 'multiple' => false)
-        );
+        try {
+            $result = $this->collection->update(
+                array('_id' => $id),
+                array('$set' => array(
+                    self::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
+                    self::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
+                )),
+                array('upsert' => true, 'multiple' => false)
+            );
+        }
+        catch (\MongoCursorException $e) {
+            return false;
+        }
 
         return isset($result['ok']) ? $result['ok'] == 1 : true;
     }


### PR DESCRIPTION
Without this commit, we sometimes have error like ```E11000 duplicate key error collection: cache.cache index: ​_id_​ dup key: { ...``` I don't know exactly what happen inside MongoDB to throw this error but the Cache interface is pretty clear that it should not throw any Exception but return a boolean to express that the cache has been saved or not