### PR TITLE
Cleanup: drop unsupported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
         - $HOME/.composer/cache
 
 php:
+    - 5.5
     - 5.6
     - 7.0
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: hhvm
+        - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,3 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: hhvm
-        - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ services:
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then pecl channel-update pecl.php.net; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then pecl install riak-beta; fi;
-    - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ./tests/travis/php.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi;
     - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/travis/php.ini; fi;

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~5.6|~7.0"
+        "php": "~5.5|~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit":         "~4.0|~5.0",
+        "phpunit/phpunit":         "~4.8|~5.0",
         "satooshi/php-coveralls":  "~0.6",
         "predis/predis":           "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": "~5.5|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit":         ">=3.7",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "~5.5|~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit":         ">=3.7",
+        "phpunit/phpunit":         "~4.0|~5.0",
         "satooshi/php-coveralls":  "~0.6",
         "predis/predis":           "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~5.5|~7.0"
+        "php": "~5.6|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit":         "~4.0|~5.0",


### PR DESCRIPTION
Because http://php.net/supported-versions.php

Also: tempted to drop 5.5 as well.