### PR TITLE
[LifeTime] Allows to set a maxLifeTime in cacheProvider

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -48,6 +48,11 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     private $namespaceVersion;
 
     /**
+     * @var integer|bool
+     */
+    private $maxLifeTime = false;
+
+    /**
      * Sets the namespace to prefix all cache ids with.
      *
      * @param string $namespace
@@ -68,6 +73,35 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     public function getNamespace()
     {
         return $this->namespace;
+    }
+
+    /**
+     * @param integer|bool $maxLifeTime
+     */
+    public function setMaxLifeTime($maxLifeTime)
+    {
+        $this->maxLifeTime = $maxLifeTime;
+    }
+
+    /**
+     * @return integer|bool
+     */
+    public function getMaxLifeTime()
+    {
+        return $this->maxLifeTime;
+    }
+
+    /**
+     * @param integer $lifeTime
+     * @return integer
+     */
+    protected function computeMaxLifeTime($lifeTime)
+    {
+        if(0 === (int)$lifeTime || (int)$lifeTime > $this->getMaxLifeTime()) {
+            $lifeTime = $this->getMaxLifeTime();
+        }
+
+        return $lifeTime;
     }
 
     /**
@@ -116,6 +150,10 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function save($id, $data, $lifeTime = 0)
     {
+        if(false !== $this->getMaxLifeTime()) {
+            $lifeTime = $this->computeMaxLifeTime($lifeTime);
+        }
+
         return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
@@ -18,4 +18,9 @@ class ApcCacheTest extends CacheTest
     {
         $this->markTestSkipped('The APC cache TTL is not working in a single process/request. See https://bugs.php.net/bug.php?id=58084');
     }
+
+    public function testMaxLifetime()
+    {
+        $this->markTestSkipped('The APC cache TTL is not working in a single process/request. See https://bugs.php.net/bug.php?id=58084');
+    }
 }

--- a/tests/Doctrine/Tests/Common/Cache/ArrayCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ArrayCacheTest.php
@@ -24,6 +24,11 @@ class ArrayCacheTest extends CacheTest
         $this->markTestSkipped('ArrayCache does not implement TTL currently.');
     }
 
+    public function testMaxLifetime()
+    {
+        $this->markTestSkipped('ArrayCache does not implement TTL currently.');
+    }
+
     protected function isSharedStorage()
     {
         return false;

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -246,6 +246,17 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->contains('expire'), 'Data should be expired');
     }
 
+    public function testMaxLifetime()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->setMaxLifeTime(1);
+        $cache->save('expire', 'value', 10);
+        $this->assertTrue($cache->contains('expire'), 'Data should not be expired yet');
+        // @TODO should more TTL-based tests pop up, so then we should mock the `time` API instead
+        sleep(2);
+        $this->assertFalse($cache->contains('expire'), 'Data should be expired');
+    }
+
     public function testNoExpire()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -18,6 +18,11 @@ class ChainCacheTest extends CacheTest
         $this->markTestSkipped('The ChainCache test uses ArrayCache which does not implement TTL currently.');
     }
 
+    public function testMaxLifetime()
+    {
+        $this->markTestSkipped('The ChainCache test uses ArrayCache which does not implement TTL currently.');
+    }
+
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();


### PR DESCRIPTION
Allows to set a maximum life-time at cacheProvider level.

Useful to set a service-wide limit,
not denying users to define their own (lower) limit for each save() call.
