### PR TITLE
Add APCu cache provider

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcuCache.php
+++ b/lib/Doctrine/Common/Cache/ApcuCache.php
@@ -20,25 +20,20 @@
 namespace Doctrine\Common\Cache;
 
 /**
- * APC cache provider.
+ * APCu cache provider.
  *
- * @link       www.doctrine-project.org
- * @deprecated since version 1.6, use ApcuCache instead
- * @since      2.0
- * @author     Benjamin Eberlei <kontakt@beberlei.de>
- * @author     Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author     Jonathan Wage <jonwage@gmail.com>
- * @author     Roman Borschel <roman@code-factory.org>
- * @author     David Abdemoulaie <dave@hobodave.com>
+ * @link   www.doctrine-project.org
+ * @since  1.6
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class ApcCache extends CacheProvider
+class ApcuCache extends CacheProvider
 {
     /**
      * {@inheritdoc}
      */
     protected function doFetch($id)
     {
-        return apc_fetch($id);
+        return apcu_fetch($id);
     }
 
     /**
@@ -46,7 +41,7 @@ class ApcCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return apc_exists($id);
+        return apcu_exists($id);
     }
 
     /**
@@ -54,7 +49,7 @@ class ApcCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        return apc_store($id, $data, $lifeTime);
+        return apcu_store($id, $data, $lifeTime);
     }
 
     /**
@@ -62,8 +57,8 @@ class ApcCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        // apc_delete returns false if the id does not exist
-        return apc_delete($id) || ! apc_exists($id);
+        // apcu_delete returns false if the id does not exist
+        return apcu_delete($id) || ! apcu_exists($id);
     }
 
     /**
@@ -71,7 +66,7 @@ class ApcCache extends CacheProvider
      */
     protected function doFlush()
     {
-        return apc_clear_cache() && apc_clear_cache('user');
+        return apcu_clear_cache();
     }
 
     /**
@@ -79,7 +74,7 @@ class ApcCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        return apc_fetch($keys);
+        return apcu_fetch($keys);
     }
 
     /**
@@ -87,15 +82,8 @@ class ApcCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        $info = apc_cache_info('', true);
-        $sma  = apc_sma_info();
-
-        // @TODO - Temporary fix @see https://github.com/krakjoe/apcu/pull/42
-        if (PHP_VERSION_ID >= 50500) {
-            $info['num_hits']   = isset($info['num_hits'])   ? $info['num_hits']   : $info['nhits'];
-            $info['num_misses'] = isset($info['num_misses']) ? $info['num_misses'] : $info['nmisses'];
-            $info['start_time'] = isset($info['start_time']) ? $info['start_time'] : $info['stime'];
-        }
+        $info = apcu_cache_info(true);
+        $sma  = apcu_sma_info();
 
         return array(
             Cache::STATS_HITS             => $info['num_hits'],

--- a/tests/Doctrine/Tests/Common/Cache/ApcuCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ApcuCacheTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Doctrine\Common\Cache\ApcuCache;
+
+/**
+ * @requires extension apcu
+ */
+class ApcuCacheTest extends CacheTest
+{
+    protected function _getCacheDriver()
+    {
+        return new ApcuCache();
+    }
+
+    public function testLifetime()
+    {
+        $this->markTestSkipped('The APC cache TTL is not working in a single process/request. See https://bugs.php.net/bug.php?id=58084');
+    }
+}


### PR DESCRIPTION
Add native APCu support (replace #112).

@guilhermeblanco, I don't think that it is possible to add `apcu_entry` support without adding a new interface to Doctrine Cache.