### PR TITLE
APC skip & fix fetchMultiple on failure

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -79,7 +79,7 @@ class ApcCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        return apc_fetch($keys);
+        return apc_fetch($keys) ?: [];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/ApcuCache.php
+++ b/lib/Doctrine/Common/Cache/ApcuCache.php
@@ -74,7 +74,7 @@ class ApcuCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        return apcu_fetch($keys);
+        return apcu_fetch($keys) ?: [];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -74,7 +74,7 @@ class MemcachedCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        return $this->memcached->getMulti($keys);
+        return $this->memcached->getMulti($keys) ?: [];
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ApcCacheTest.php
@@ -9,6 +9,13 @@ use Doctrine\Common\Cache\ApcCache;
  */
 class ApcCacheTest extends CacheTest
 {
+    protected function setUp()
+    {
+        if (!ini_get('apc.enable_cli')) {
+            $this->markTestSkipped('APC must be enabled for the CLI with the ini setting apc.enable_cli=1');
+        }
+    }
+
     protected function _getCacheDriver()
     {
         return new ApcCache();

--- a/tests/Doctrine/Tests/Common/Cache/ApcuCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ApcuCacheTest.php
@@ -9,6 +9,13 @@ use Doctrine\Common\Cache\ApcuCache;
  */
 class ApcuCacheTest extends CacheTest
 {
+    protected function setUp()
+    {
+        if (!ini_get('apc.enable_cli')) {
+            $this->markTestSkipped('APC must be enabled for the CLI with the ini setting apc.enable_cli=1');
+        }
+    }
+
     protected function _getCacheDriver()
     {
         return new ApcuCache();


### PR DESCRIPTION
1. skip apc tests if apc.enable_cli is not enabled instead of failing (unfortunately this setting cannot be enabled at runtime)
2. fix fetchMultiple implementations that can return false on failure instead of an array. I realized this when looking at the test results in #136

> 1) Doctrine\Tests\Common\Cache\ApcCacheTest::testFetchMultiple
array_key_exists() expects parameter 2 to be array, boolean given
C:\Users\fr-mktg-od\Desktop\Sites\cache\lib\Doctrine\Common\Cache\CacheProvider.php:98