### PR TITLE
TaggedCache support

### DIFF
--- a/lib/Doctrine/Common/Cache/TaggedCache.php
+++ b/lib/Doctrine/Common/Cache/TaggedCache.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+interface TaggedCache
+{
+    /**
+     * @param array|string[] $tags
+     *
+     * @return array|string[]
+     */
+    public function fetchByTags(array $tags = array());
+
+    /**
+     * @param string         $id
+     * @param array|string[] $tags
+     *
+     * @return bool
+     */
+    public function tag($id, array $tags = array());
+
+    /**
+     * @param array|string[] $tags
+     *
+     * @return bool
+     */
+    public function deleteByTags(array $tags = array());
+}


### PR DESCRIPTION
As explained in #143 I want to be able to tag cache items and to fetch / remove them from the cache by tags.

The default implementation is ugly; tags are comma separated values in a cache key.

The redis / predis implementations however work with native redis datatypes (`sets`) and ensure atomic add operations on the tags. Redis also allows intersection operations on `sets` so fetching based on the intersection of multiple tags is trivial.

MongoDB also has `$setIntersection` for arrays so it would be a good candidate for a similar implementation.

* CacheProvider, RedisCache, PredisCache
 * [x] fetchByTags
 * [x] tag
 * [x] deleteByTags

