### PR TITLE
Fix save multiple on memcached

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -86,7 +86,7 @@ class MemcachedCache extends CacheProvider
             $lifetime = time() + $lifetime;
         }
 
-        return $this->memcached->setMulti($keysAndValues, null, $lifetime);
+        return $this->memcached->setMulti($keysAndValues, $lifetime);
     }
 
     /**


### PR DESCRIPTION
The `setMulti` signature for memcached is http://php.net/manual/en/memcached.setmulti.php:
```php
public bool Memcached::setMulti ( array $items [, int $expiration ] )
```
But there are more... In the extension definition (https://github.com/php-memcached-dev/php-memcached/blob/master/php_memcached.c#L1252) this has a third param.

This fixes passing the `$lifetime` instead of the `udf_flags`.