### PR TITLE
Redis::doSaveMultiple: Changed the condition of using the lifetime argument

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -88,14 +88,14 @@ class RedisCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doSaveMultiple(array $keysAndValues, $lifetime = 0)
+    protected function doSaveMultiple(array $keysAndValues, $lifeTime = 0)
     {
-        if ($lifetime) {
+        if ($lifeTime) {
             $success = true;
 
             // Keys have lifetime, use SETEX for each of them
             foreach ($keysAndValues as $key => $value) {
-                if (!$this->redis->setex($key, $lifetime, $value)) {
+                if (!$this->redis->setex($key, $lifeTime, $value)) {
                     $success = false;
                 }
             }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -90,7 +90,7 @@ class RedisCache extends CacheProvider
      */
     protected function doSaveMultiple(array $keysAndValues, $lifeTime = 0)
     {
-        if ($lifeTime) {
+        if ($lifeTime > 0) {
             $success = true;
 
             // Keys have lifetime, use SETEX for each of them


### PR DESCRIPTION
It is necessary to use the new condition because the old one was TRUE when a negative value passed.