### PR TITLE
Added MemcacheCache::doFetchMultiple() method

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -72,6 +72,14 @@ class MemcacheCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
+    protected function doFetchMultiple(array $keys)
+    {
+        return $this->memcache->get($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doContains($id)
     {
         $flags = null;


### PR DESCRIPTION
Memcache can to fetch the values by multiple keys and it doesn't need to use doContains, because Memcache doesn't fetch the non-existent values.
