### PR TITLE
Cache anything with PhpFileCache

### DIFF
--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -85,12 +85,12 @@ class PhpFileCache extends FileCache
             'data'      => $data
         );
 
-        if (is_object($data) && ! method_exists($data, '__set_state')) {
-            $value  = var_export(serialize($value), true);
-            $code   = sprintf('<?php return unserialize(%s);', $value);
-        } else {
+        if (is_object($data) && method_exists($data, '__set_state')) {
             $value  = var_export($value, true);
             $code   = sprintf('<?php return %s;', $value);
+        } else {
+            $value  = var_export(serialize($value), true);
+            $code   = sprintf('<?php return unserialize(%s);', $value);
         }
 
         return $this->writeFile($filename, $code);

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -78,14 +78,6 @@ class PhpFileCache extends FileCache
             $lifeTime = time() + $lifeTime;
         }
 
-        if (is_object($data) && ! method_exists($data, '__set_state')) {
-            throw new \InvalidArgumentException(
-                "Invalid argument given, PhpFileCache only allows objects that implement __set_state() " .
-                "and fully support var_export(). You can use the FilesystemCache to save arbitrary object " .
-                "graphs using serialize()/deserialize()."
-            );
-        }
-
         $filename  = $this->getFilename($id);
 
         $value = array(
@@ -93,8 +85,13 @@ class PhpFileCache extends FileCache
             'data'      => $data
         );
 
-        $value  = var_export($value, true);
-        $code   = sprintf('<?php return %s;', $value);
+        if (is_object($data) && ! method_exists($data, '__set_state')) {
+            $value  = var_export(serialize($value), true);
+            $code   = sprintf('<?php return unserialize(%s);', $value);
+        } else {
+            $value  = var_export($value, true);
+            $code   = sprintf('<?php return %s;', $value);
+        }
 
         return $this->writeFile($filename, $code);
     }

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -45,11 +45,31 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         $cache = $this->_getCacheDriver();
 
-        $cache->save('test_not_set_state', new NotSetStateClass(array(1,2,3)));
+        // Test save
+        $cache->save('test_not_set_state', new NotSetStateClass(array(5,6,7)));
+
+        // Test fetch
         $value = $cache->fetch('test_not_set_state');
         $this->assertInstanceOf('Doctrine\Tests\Common\Cache\NotSetStateClass', $value);
-        $this->assertEquals(array(1,2,3), $value->getValue());
+        $this->assertEquals(array(5,6,7), $value->getValue());
+
+        // Test contains
         $this->assertTrue($cache->contains('test_not_set_state'));
+    }
+
+    public function testNotImplementsSetStateInArray()
+    {
+        $cache = $this->_getCacheDriver();
+
+        // Test save
+        $cache->save('test_not_set_state_in_array', [new NotSetStateClass(array(4,3,2))]);
+
+        // Test fetch
+        $value = $cache->fetch('test_not_set_state_in_array');
+        $this->assertEquals(array(4,3,2), $value[0]->getValue());
+
+        // Test contains
+        $this->assertTrue($cache->contains('test_not_set_state_in_array'));
     }
 
     public function testGetStats()

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -14,7 +14,6 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         $data = parent::provideDataToCache();
 
-        unset($data['object'], $data['object_recursive']); // PhpFileCache only allows objects that implement __set_state() and fully support var_export()
         unset($data['float_zero']); // var_export exports float(0) as int(0)
 
         return $data;
@@ -46,8 +45,11 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         $cache = $this->_getCacheDriver();
 
-        $this->setExpectedException('InvalidArgumentException');
         $cache->save('test_not_set_state', new NotSetStateClass(array(1,2,3)));
+        $value = $cache->fetch('test_not_set_state');
+        $this->assertInstanceOf('Doctrine\Tests\Common\Cache\NotSetStateClass', $value);
+        $this->assertEquals(array(1,2,3), $value->getValue());
+        $this->assertTrue($cache->contains('test_not_set_state'));
     }
 
     public function testGetStats()


### PR DESCRIPTION
Currently PhpFileCache is a bit useless for doctrine, since it can't cache variables without __set_state implemented. Even MetadataInfo doesn't implement __set_state iirc. The error recommends using FilesystemCache instead, but it's much slower.

Simply adding support for serializing variable before var_export makes this class usable again, and it performs better than FilesystemCache.

I think there is no reason to avoid serialize at all cost, as other cache methods use it anyway.