### PR TITLE
Add MultiDeleteCache interface and default CacheProvider implementation

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -28,8 +28,9 @@ namespace Doctrine\Common\Cache;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author Benoit Burnichon <bburnichon@gmail.com>
  */
-abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, MultiGetCache, MultiPutCache
+abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, MultiGetCache, MultiPutCache, MultiDeleteCache
 {
     const DOCTRINE_NAMESPACE_CACHEKEY = 'DoctrineNamespaceCacheKey[%s]';
 
@@ -130,6 +131,19 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     public function save($id, $data, $lifeTime = 0)
     {
         return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMultiple(array $keys)
+    {
+        $namespacedKeys = array();
+        foreach ($keys as $key) {
+            $namespacedKeys[] = $this->getNamespacedId($key);
+        }
+
+        return $this->doDeleteMultiple($namespacedKeys);
     }
 
     /**
@@ -284,6 +298,26 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      * @return bool TRUE if the entry was successfully stored in the cache, FALSE otherwise.
      */
     abstract protected function doSave($id, $data, $lifeTime = 0);
+
+    /**
+     * Default implementation of doDeleteMultiple. Each driver that supports multi-delete should override it.
+     *
+     * @param array $keys Array of keys to delete from cache
+     *
+     * @return bool TRUE if the operation was successful, FALSE if it wasn't
+     */
+    protected function doDeleteMultiple(array $keys)
+    {
+        $success = true;
+
+        foreach ($keys as $key) {
+            if (!$this->doDelete($key)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
 
     /**
      * Deletes a cache entry.

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -138,12 +138,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function deleteMultiple(array $keys)
     {
-        $namespacedKeys = array();
-        foreach ($keys as $key) {
-            $namespacedKeys[] = $this->getNamespacedId($key);
-        }
-
-        return $this->doDeleteMultiple($namespacedKeys);
+        return $this->doDeleteMultiple(array_map(array($this, 'getNamespacedId'), $keys));
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -38,7 +38,9 @@ class ChainCache extends CacheProvider
      */
     public function __construct($cacheProviders = array())
     {
-        $this->cacheProviders = $cacheProviders;
+        $this->cacheProviders = $cacheProviders instanceof \Traversable
+            ? iterator_to_array($cacheProviders, false)
+            : array_values($cacheProviders);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -112,6 +112,15 @@ class MemcachedCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
+    protected function doDeleteMultiple(array $keys)
+    {
+        return $this->memcached->deleteMulti($keys)
+            || $this->memcached->getResultCode() === Memcached::RES_NOTFOUND;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doDelete($id)
     {
         return $this->memcached->delete($id)

--- a/lib/Doctrine/Common/Cache/MultiDeleteCache.php
+++ b/lib/Doctrine/Common/Cache/MultiDeleteCache.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+/**
+ * Interface for cache drivers that allows to put many items at once.
+ *
+ * @link   www.doctrine-project.org
+ * @since  1.7
+ * @author Benoit Burnichon <bburnichon@gmail.com>
+ */
+interface MultiDeleteCache
+{
+    /**
+     * Returns a boolean value indicating if the operation succeeded.
+     *
+     * @param array $keys Array of keys to delete from cache
+     *
+     * @return bool TRUE if the operation was successful, FALSE if it wasn't.
+     */
+    function deleteMultiple(array $keys);
+}

--- a/lib/Doctrine/Common/Cache/MultiDeleteCache.php
+++ b/lib/Doctrine/Common/Cache/MultiDeleteCache.php
@@ -29,9 +29,9 @@ namespace Doctrine\Common\Cache;
 interface MultiDeleteCache
 {
     /**
-     * Returns a boolean value indicating if the operation succeeded.
+     * Deletes several cache entries.
      *
-     * @param array $keys Array of keys to delete from cache
+     * @param string[] $keys Array of keys to delete from cache
      *
      * @return bool TRUE if the operation was successful, FALSE if it wasn't.
      */

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -100,4 +100,35 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
             'kok'   => 'vok',
         ));
     }
+
+    public function testDeleteMultipleNoFail()
+    {
+        /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->getMockForAbstractClass(
+            'Doctrine\Common\Cache\CacheProvider',
+            array(),
+            '',
+            true,
+            true,
+            true,
+            array('doDelete')
+        );
+
+        $cache
+            ->expects($this->at(1))
+            ->method('doDelete')
+            ->with('[kerr][1]')
+            ->will($this->returnValue(false));
+
+        $cache
+            ->expects($this->at(2))
+            ->method('doDelete')
+            ->with('[kok][1]')
+            ->will($this->returnValue(true));
+
+        $cache->deleteMultiple(array(
+            'kerr',
+            'kok',
+        ));
+    }
 }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -175,6 +175,18 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->contains('key2'));
     }
 
+    public function testDeleteMulti()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $this->assertTrue($cache->save('key1', 1));
+        $this->assertTrue($cache->save('key2', 1));
+        $this->assertTrue($cache->deleteMultiple(array('key1', 'key2', 'key3')));
+        $this->assertFalse($cache->contains('key1'));
+        $this->assertFalse($cache->contains('key2'));
+        $this->assertFalse($cache->contains('key3'));
+    }
+
     /**
      * @dataProvider provideCacheIds
      */

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -13,11 +13,6 @@ class ChainCacheTest extends CacheTest
         return new ChainCache(array(new ArrayCache()));
     }
 
-    public function testLifetime()
-    {
-        $this->markTestSkipped('The ChainCache test uses ArrayCache which does not implement TTL currently.');
-    }
-
     public function testGetStats()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -61,7 +61,7 @@ class ChainCacheTest extends CacheTest
         $result = $chainCache->fetch('bar');
 
         $this->assertEquals('value', $result);
-        $this->assertTrue($cache2->contains('bar'));
+        $this->assertTrue($cache1->contains('bar'));
     }
 
     public function testFetchMultiplePropagateToFastestCache()

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -39,6 +39,19 @@ class ChainCacheTest extends CacheTest
         $this->assertEquals('bar', $chainCache->fetch('id'));
     }
 
+    public function testOnlyFetchFirstCompleteSet()
+    {
+        $cache1 = new ArrayCache();
+        $cache2 = $this->getMockForAbstractClass('Doctrine\Common\Cache\CacheProvider');
+
+        $cache2->expects($this->never())->method('doFetchMultiple');
+
+        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache->saveMultiple(array('bar' => 'Bar', 'foo' => 'Foo'));
+
+        $this->assertEquals(array('bar' => 'Bar', 'foo' => 'Foo'), $chainCache->fetchMultiple(array('bar', 'foo')));
+    }
+
     public function testFetchPropagateToFastestCache()
     {
         $cache1 = new ArrayCache();
@@ -54,6 +67,25 @@ class ChainCacheTest extends CacheTest
 
         $this->assertEquals('value', $result);
         $this->assertTrue($cache2->contains('bar'));
+    }
+
+    public function testFetchMultiplePropagateToFastestCache()
+    {
+        $cache1 = new ArrayCache();
+        $cache2 = new ArrayCache();
+
+        $cache1->save('bar', 'Bar');
+        $cache2->saveMultiple(array('bar' => 'Bar', 'foo' => 'Foo'));
+
+        $chainCache = new ChainCache(array($cache1, $cache2));
+
+        $this->assertTrue($cache1->contains('bar'));
+        $this->assertFalse($cache1->contains('foo'));
+
+        $result = $chainCache->fetchMultiple(array('bar', 'foo'));
+
+        $this->assertEquals(array('bar' => 'Bar', 'foo' => 'Foo'), $result);
+        $this->assertTrue($cache1->contains('foo'));
     }
 
     public function testNamespaceIsPropagatedToAllProviders()
@@ -78,6 +110,22 @@ class ChainCacheTest extends CacheTest
 
         $chainCache = new ChainCache(array($cache1, $cache2));
         $chainCache->delete('bar');
+    }
+
+    public function testDeleteMultipleToAllProviders()
+    {
+        $cache1 = $this->getMockBuilder('Doctrine\Common\Cache\CacheProvider')
+            ->setMethods(array('doDeleteMultiple'))
+            ->getMockForAbstractClass();
+        $cache2 = $this->getMockBuilder('Doctrine\Common\Cache\CacheProvider')
+            ->setMethods(array('doDeleteMultiple'))
+            ->getMockForAbstractClass();
+
+        $cache1->expects($this->once())->method('doDeleteMultiple')->willReturn(true);
+        $cache2->expects($this->once())->method('doDeleteMultiple')->willReturn(true);
+
+        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache->deleteMultiple(array('bar', 'foo'));
     }
 
     public function testFlushToAllProviders()


### PR DESCRIPTION
I have a case where I need to invalidate several keys at once. This port the addition I made to provide it to all users of this library.

Also add memcached implementation.
