### PR TITLE
Bug fix: treating null lifetime as infinite in PhpFileCache

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -129,7 +129,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);
+        return $this->doSave($this->getNamespacedId($id), $data, (int) $lifeTime);
     }
 
     /**
@@ -265,7 +265,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         $success = true;
 
         foreach ($keysAndValues as $key => $value) {
-            if (!$this->doSave($key, $value, $lifetime)) {
+            if (!$this->doSave($key, $value, (int) $lifetime)) {
                 $success = false;
             }
         }

--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -81,7 +81,7 @@ class CouchbaseCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
-        return $this->couchbase->set($id, $data, (int) $lifeTime);
+        return $this->couchbase->set($id, $data, $lifeTime);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -89,7 +89,7 @@ class MemcacheCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
-        return $this->memcache->set($id, $data, 0, (int) $lifeTime);
+        return $this->memcache->set($id, $data, 0, $lifeTime);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -106,7 +106,7 @@ class MemcachedCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
-        return $this->memcached->set($id, $data, (int) $lifeTime);
+        return $this->memcached->set($id, $data, $lifeTime);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -89,7 +89,7 @@ class PhpFileCache extends FileCache
         $filename  = $this->getFilename($id);
 
         $value = array(
-            'lifetime'  => $lifeTime,
+            'lifetime'  => (int) $lifeTime,
             'data'      => $data
         );
 

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -89,7 +89,7 @@ class PhpFileCache extends FileCache
         $filename  = $this->getFilename($id);
 
         $value = array(
-            'lifetime'  => (int) $lifeTime,
+            'lifetime'  => $lifeTime,
             'data'      => $data
         );
 

--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -53,7 +53,7 @@ class XcacheCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        return xcache_set($id, serialize($data), (int) $lifeTime);
+        return xcache_set($id, serialize($data), $lifeTime);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -262,6 +262,13 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->contains('expire'), 'Data should be expired');
     }
 
+    public function testNullLifetime()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('nulllifetime', 'value', null);
+        $this->assertTrue($cache->contains('nulllifetime'), 'Data should not be expired');
+    }
+
     public function testNoExpire()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -269,6 +269,17 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($cache->contains('nulllifetime'), 'Data should not be expired');
     }
 
+    public function testNullLifetimeMultiple()
+    {
+        $cache = $this->_getCacheDriver();
+        $data = [
+            'nulllifetime' => 'value',
+            'otherkey' => 'othervalue'
+        ];
+        $cache->saveMultiple($data, null);
+        $this->assertTrue($cache->contains('nulllifetime'), 'Data should not be expired');
+    }
+
     public function testNoExpire()
     {
         $cache = $this->_getCacheDriver();


### PR DESCRIPTION
According to docs ( https://github.com/doctrine/doctrine2/blob/13473e8b4ed5dfe6fe1d3a053f8ab8d22752cfe7/docs/en/reference/caching.rst#saving ), null $lifetime should mean infinite lifetime. However, PhpFileCache does isset($value['lifetime']) to determine whether value exists (which returns false for null).

This PR fixes that bug and adds test with null lifetime.
