### PR TITLE
Exclude some dirs and files from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests/ export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 /tests/ export-ignore
 /.* export-ignore
+/build.xml export-ignore
+/build.properties export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
People that install this library via composer don't need to build/test, they just need the library itself.
This PR removes the development directories and files from the repository auto-generated ZIP archives.
Since these development files/directories will still be available via `git clone`, Travis is happy, developers are happy, and so are end-users (they won't have unneeded stuff in production machines).