### PR TITLE
Added CacheProvider::fetchAndSave() method

### DIFF
--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -89,6 +89,20 @@ interface Cache
     public function delete($id);
 
     /**
+     * Fetches an entry from the cache, if it exists.
+     * If it doesn't, put it into the cache and return
+     *
+     * @param string $id       The cache id.
+     * @param mixed  $data     The cache entry/data.
+     * @param int    $lifeTime The lifetime in number of seconds for this cache entry.
+     *                         If zero (the default), the entry never expires (although it may be deleted from the cache
+     *                         to make place for other entries).
+     *
+     * @return mixed The cached data or FALSE, if no cache entry exists for the given id.
+     */
+    public function fetchAndSave($id, $data, $lifeTime = 0);
+
+    /**
      * Retrieves cached information from the data store.
      *
      * The server's statistics array has the following values:

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -135,6 +135,20 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     /**
      * {@inheritdoc}
      */
+    public function fetchAndSave($id, $data, $lifeTime = 0)
+    {
+        if ($this->contains($id)) {
+            return $this->fetch($id);
+        }
+
+        $this->save($id, $data, $lifeTime);
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function delete($id)
     {
         return $this->doDelete($this->getNamespacedId($id));

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\Common\Cache;
 
+use Doctrine\Common\Cache\CacheProvider;
+
 class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
 {
     public function testFetchMultiWillFilterNonRequestedKeys()
@@ -99,5 +101,57 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
             'kerr'  => 'verr',
             'kok'   => 'vok',
         ));
+    }
+
+    public function testSaveItIfNotExists()
+    {
+        $cacheEntry = 'foo';
+        $cacheValue = 'bar';
+
+        $cache = $this->getMockBuilder(CacheProvider::class)
+            ->setMethods(['contains', 'fetch', 'save'])
+            ->getMockForAbstractClass();
+
+        $cache->expects($this->once())
+            ->method('contains')
+            ->with($cacheEntry)
+            ->will($this->returnValue(false));
+
+        $cache->expects($this->once())
+            ->method('save')
+            ->with($cacheEntry, $cacheValue, 0)
+            ->will($this->returnValue(true));
+
+        $cache->expects($this->never())
+            ->method('fetch');
+
+        $result = $cache->fetchAndSave($cacheEntry, $cacheValue, 0);
+        $this->assertEquals($cacheValue, $result);
+    }
+
+    public function testFetchIfExists()
+    {
+        $cacheEntry = 'foo';
+        $cacheValue = 'bar';
+
+        $cache = $this->getMockBuilder(CacheProvider::class)
+            ->setMethods(['contains', 'fetch', 'save'])
+            ->getMockForAbstractClass();
+
+        $cache->expects($this->once())
+            ->method('contains')
+            ->with($cacheEntry)
+            ->will($this->returnValue(true));
+
+        $cache->expects($this->once())
+            ->method('fetch')
+            ->with($cacheEntry)
+            ->will($this->returnValue($cacheValue));
+
+        $cache->expects($this->never())
+            ->method('save');
+
+        $result = $cache->fetchAndSave($cacheEntry, $cacheValue, 0);
+        $this->assertEquals($cacheValue, $result);
     }
 }


### PR DESCRIPTION
I found myself writing this over and over, so I thought it could be a nice addition to the cache provider