### PR TITLE
throw an error if cannot delete

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -164,7 +164,7 @@ abstract class FileCache extends CacheProvider
     {
         $filename = $this->getFilename($id);
 
-        return @unlink($filename) || ! file_exists($filename);
+        return ! file_exists($filename) || unlink($filename);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -164,7 +164,7 @@ abstract class FileCache extends CacheProvider
     {
         $filename = $this->getFilename($id);
 
-        return ! file_exists($filename) || unlink($filename);
+        return ! file_exists($filename) || unlink($filename) || ! file_exists($filename);
     }
 
     /**


### PR DESCRIPTION
Check if file exists first to remove the error if it does not exists and throw an error for easier debugging if there is a different issue.

this would've saved me hours