### PR TITLE
Added link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 [![Latest Stable Version](https://poser.pugx.org/doctrine/cache/v/stable.png)](https://packagist.org/packages/doctrine/cache) [![Total Downloads](https://poser.pugx.org/doctrine/cache/downloads.png)](https://packagist.org/packages/doctrine/cache)
 
-Cache component extracted from the Doctrine Common project.
+Cache component extracted from the Doctrine Common project. [Documentation](http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/reference/caching.html)


### PR DESCRIPTION
Since this repo is linked to packagist, it would be nice to have an easy to find link to the documentation.