### PR TITLE
Fix: exists() returns an integer

### DIFF
--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -99,7 +99,7 @@ class PredisCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return $this->client->exists($id);
+        return $this->client->exists($id) !== 0;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] assumes that `Redis::exists()` returns `0` if the cache doesn't contain data for an `$id`

💁 For reference, see http://redis.io/commands/EXISTS#return-value.

