### PR TITLE
Fix: Second parameter should probably be an assertion message

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -60,7 +60,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->fetch('KEY'));
 
         $cache->delete('KEY');
-        $this->assertTrue($cache->contains('key', 'Deleting cache item with different case must not affect other cache item'));
+        $this->assertTrue($cache->contains('key'), 'Deleting cache item with different case must not affect other cache item');
     }
 
     public function testFetchMultiple()


### PR DESCRIPTION
This PR

* [x] moves an argument into the right place