### PR TITLE
Fix: Class name does not match file name

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
@@ -9,7 +9,7 @@ use SQLite3;
 /**
  * @requires extension sqlite3
  */
-class SQLite3Test extends CacheTest
+class SQLite3CacheTest extends CacheTest
 {
     private $file;
     private $sqlite;


### PR DESCRIPTION
This PR

* [x] renames a test class so it matches the name of the containing file