### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -107,12 +107,12 @@ class ApcCache extends CacheProvider
             $info['start_time'] = isset($info['start_time']) ? $info['start_time'] : $info['stime'];
         }
 
-        return array(
+        return [
             Cache::STATS_HITS             => $info['num_hits'],
             Cache::STATS_MISSES           => $info['num_misses'],
             Cache::STATS_UPTIME           => $info['start_time'],
             Cache::STATS_MEMORY_USAGE     => $info['mem_size'],
             Cache::STATS_MEMORY_AVAILABLE => $sma['avail_mem'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/ApcuCache.php
+++ b/lib/Doctrine/Common/Cache/ApcuCache.php
@@ -95,12 +95,12 @@ class ApcuCache extends CacheProvider
         $info = apcu_cache_info(true);
         $sma  = apcu_sma_info();
 
-        return array(
+        return [
             Cache::STATS_HITS             => $info['num_hits'],
             Cache::STATS_MISSES           => $info['num_misses'],
             Cache::STATS_UPTIME           => $info['start_time'],
             Cache::STATS_MEMORY_USAGE     => $info['mem_size'],
             Cache::STATS_MEMORY_AVAILABLE => $sma['avail_mem'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -84,13 +84,13 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     public function fetchMultiple(array $keys)
     {
         if (empty($keys)) {
-            return array();
+            return [];
         }
         
         // note: the array_combine() is in place to keep an association between our $keys and the $namespacedKeys
-        $namespacedKeys = array_combine($keys, array_map(array($this, 'getNamespacedId'), $keys));
+        $namespacedKeys = array_combine($keys, array_map([$this, 'getNamespacedId'], $keys));
         $items          = $this->doFetchMultiple($namespacedKeys);
-        $foundItems     = array();
+        $foundItems     = [];
 
         // no internal array function supports this sort of mapping: needs to be iterative
         // this filters and combines keys in one pass
@@ -108,7 +108,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function saveMultiple(array $keysAndValues, $lifetime = 0)
     {
-        $namespacedKeysAndValues = array();
+        $namespacedKeysAndValues = [];
         foreach ($keysAndValues as $key => $value) {
             $namespacedKeysAndValues[$this->getNamespacedId($key)] = $value;
         }
@@ -222,7 +222,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     protected function doFetchMultiple(array $keys)
     {
-        $returnValues = array();
+        $returnValues = [];
 
         foreach ($keys as $key) {
             if (false !== ($item = $this->doFetch($key)) || $this->doContains($key)) {

--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -29,14 +29,14 @@ class ChainCache extends CacheProvider
     /**
      * @var CacheProvider[]
      */
-    private $cacheProviders = array();
+    private $cacheProviders = [];
 
     /**
      * Constructor
      *
      * @param CacheProvider[] $cacheProviders
      */
-    public function __construct($cacheProviders = array())
+    public function __construct($cacheProviders = [])
     {
         $this->cacheProviders = $cacheProviders;
     }
@@ -136,7 +136,7 @@ class ChainCache extends CacheProvider
     protected function doGetStats()
     {
         // We return all the stats from all adapters
-        $stats = array();
+        $stats = [];
 
         foreach ($this->cacheProviders as $cacheProvider) {
             $stats[] = $cacheProvider->doGetStats();

--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -110,12 +110,12 @@ class CouchbaseCache extends CacheProvider
         $server  = explode(":", $servers[0]);
         $key     = $server[0] . ":" . "11210";
         $stats   = $stats[$key];
-        return array(
+        return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],
             Cache::STATS_UPTIME => $stats['uptime'],
             Cache::STATS_MEMORY_USAGE     => $stats['bytes'],
             Cache::STATS_MEMORY_AVAILABLE => $stats['limit_maxbytes'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -202,13 +202,13 @@ abstract class FileCache extends CacheProvider
 
         $free = disk_free_space($this->directory);
 
-        return array(
+        return [
             Cache::STATS_HITS               => null,
             Cache::STATS_MISSES             => null,
             Cache::STATS_UPTIME             => null,
             Cache::STATS_MEMORY_USAGE       => $usage,
             Cache::STATS_MEMORY_AVAILABLE   => $free,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -115,12 +115,12 @@ class MemcacheCache extends CacheProvider
     protected function doGetStats()
     {
         $stats = $this->memcache->getStats();
-        return array(
+        return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],
             Cache::STATS_UPTIME => $stats['uptime'],
             Cache::STATS_MEMORY_USAGE     => $stats['bytes'],
             Cache::STATS_MEMORY_AVAILABLE => $stats['limit_maxbytes'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -135,12 +135,12 @@ class MemcachedCache extends CacheProvider
         $servers = $this->memcached->getServerList();
         $key     = $servers[0]['host'] . ':' . $servers[0]['port'];
         $stats   = $stats[$key];
-        return array(
+        return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],
             Cache::STATS_UPTIME => $stats['uptime'],
             Cache::STATS_MEMORY_USAGE     => $stats['bytes'],
             Cache::STATS_MEMORY_AVAILABLE => $stats['limit_maxbytes'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -82,7 +82,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        $document = $this->collection->findOne(array('_id' => $id), array(self::DATA_FIELD, self::EXPIRATION_FIELD));
+        $document = $this->collection->findOne(['_id' => $id], [self::DATA_FIELD, self::EXPIRATION_FIELD]);
 
         if ($document === null) {
             return false;
@@ -101,7 +101,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        $document = $this->collection->findOne(array('_id' => $id), array(self::EXPIRATION_FIELD));
+        $document = $this->collection->findOne(['_id' => $id], [self::EXPIRATION_FIELD]);
 
         if ($document === null) {
             return false;
@@ -122,12 +122,12 @@ class MongoDBCache extends CacheProvider
     {
         try {
             $result = $this->collection->update(
-                array('_id' => $id),
-                array('$set' => array(
+                ['_id' => $id],
+                ['$set' => [
                     self::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
                     self::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
-                )),
-                array('upsert' => true, 'multiple' => false)
+                ]],
+                ['upsert' => true, 'multiple' => false]
             );
         } catch (MongoCursorException $e) {
             return false;
@@ -141,7 +141,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        $result = $this->collection->remove(array('_id' => $id));
+        $result = $this->collection->remove(['_id' => $id]);
 
         return isset($result['ok']) ? $result['ok'] == 1 : true;
     }
@@ -162,23 +162,23 @@ class MongoDBCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        $serverStatus = $this->collection->db->command(array(
+        $serverStatus = $this->collection->db->command([
             'serverStatus' => 1,
             'locks' => 0,
             'metrics' => 0,
             'recordStats' => 0,
             'repl' => 0,
-        ));
+        ]);
 
-        $collStats = $this->collection->db->command(array('collStats' => 1));
+        $collStats = $this->collection->db->command(['collStats' => 1]);
 
-        return array(
+        return [
             Cache::STATS_HITS => null,
             Cache::STATS_MISSES => null,
             Cache::STATS_UPTIME => (isset($serverStatus['uptime']) ? (int) $serverStatus['uptime'] : null),
             Cache::STATS_MEMORY_USAGE => (isset($collStats['size']) ? (int) $collStats['size'] : null),
             Cache::STATS_MEMORY_AVAILABLE  => null,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -88,10 +88,10 @@ class PhpFileCache extends FileCache
 
         $filename  = $this->getFilename($id);
 
-        $value = array(
+        $value = [
             'lifetime'  => $lifeTime,
             'data'      => $data
-        );
+        ];
 
         $value  = var_export($value, true);
         $code   = sprintf('<?php return %s;', $value);

--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -61,7 +61,7 @@ class PredisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        $fetchedItems = call_user_func_array(array($this->client, 'mget'), $keys);
+        $fetchedItems = call_user_func_array([$this->client, 'mget'], $keys);
 
         return array_map('unserialize', array_filter(array_combine($keys, $fetchedItems)));
     }
@@ -142,12 +142,12 @@ class PredisCache extends CacheProvider
     {
         $info = $this->client->info();
 
-        return array(
+        return [
             Cache::STATS_HITS              => $info['Stats']['keyspace_hits'],
             Cache::STATS_MISSES            => $info['Stats']['keyspace_misses'],
             Cache::STATS_UPTIME            => $info['Server']['uptime_in_seconds'],
             Cache::STATS_MEMORY_USAGE      => $info['Memory']['used_memory'],
             Cache::STATS_MEMORY_AVAILABLE  => false
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -74,7 +74,7 @@ class RedisCache extends CacheProvider
         $fetchedItems = array_combine($keys, $this->redis->mget($keys));
 
         // Redis mget returns false for keys that do not exist. So we need to filter those out unless it's the real data.
-        $foundItems   = array();
+        $foundItems   = [];
 
         foreach ($fetchedItems as $key => $value) {
             if (false !== $value || $this->redis->exists($key)) {
@@ -149,13 +149,13 @@ class RedisCache extends CacheProvider
     protected function doGetStats()
     {
         $info = $this->redis->info();
-        return array(
+        return [
             Cache::STATS_HITS   => $info['keyspace_hits'],
             Cache::STATS_MISSES => $info['keyspace_misses'],
             Cache::STATS_UPTIME => $info['uptime_in_seconds'],
             Cache::STATS_MEMORY_USAGE      => $info['used_memory'],
             Cache::STATS_MEMORY_AVAILABLE  => false
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -201,7 +201,7 @@ class SQLite3Cache extends CacheProvider
      */
     private function getFields()
     {
-        return array(static::ID_FIELD, static::DATA_FIELD, static::EXPIRATION_FIELD);
+        return [static::ID_FIELD, static::DATA_FIELD, static::EXPIRATION_FIELD];
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/WinCacheCache.php
+++ b/lib/Doctrine/Common/Cache/WinCacheCache.php
@@ -98,12 +98,12 @@ class WinCacheCache extends CacheProvider
         $info    = wincache_ucache_info();
         $meminfo = wincache_ucache_meminfo();
 
-        return array(
+        return [
             Cache::STATS_HITS             => $info['total_hit_count'],
             Cache::STATS_MISSES           => $info['total_miss_count'],
             Cache::STATS_UPTIME           => $info['total_cache_uptime'],
             Cache::STATS_MEMORY_USAGE     => $meminfo['memory_total'],
             Cache::STATS_MEMORY_AVAILABLE => $meminfo['memory_free'],
-        );
+        ];
     }
 }

--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -101,12 +101,12 @@ class XcacheCache extends CacheProvider
         $this->checkAuthorization();
 
         $info = xcache_info(XC_TYPE_VAR, 0);
-        return array(
+        return [
             Cache::STATS_HITS   => $info['hits'],
             Cache::STATS_MISSES => $info['misses'],
             Cache::STATS_UPTIME => null,
             Cache::STATS_MEMORY_USAGE      => $info['size'],
             Cache::STATS_MEMORY_AVAILABLE  => $info['avail'],
-        );
+        ];
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BaseFileCacheTest.php
@@ -60,12 +60,12 @@ abstract class BaseFileCacheTest extends CacheTest
         // Windows officially supports 260 bytes including null terminator
         // 259 characters is too large due to PHP bug (https://bugs.php.net/bug.php?id=70943)
         // 260 characters is too large - null terminator is included in allowable length
-        return array(
-            array(257, false),
-            array(258, false),
-            array(259, true),
-            array(260, true)
-        );
+        return [
+            [257, false],
+            [258, false],
+            [259, true],
+            [260, true]
+        ];
     }
 
     private static function getBasePathForWindowsPathLengthTests($pathLength)
@@ -106,7 +106,7 @@ abstract class BaseFileCacheTest extends CacheTest
             . '_' . $keyHash
             . '.doctrine.cache';
 
-        return array($key, $keyPath, $hashedKeyPath);
+        return [$key, $keyPath, $hashedKeyPath];
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -9,26 +9,26 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
         /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
         $cache = $this->getMockForAbstractClass(
             'Doctrine\Common\Cache\CacheProvider',
-            array(),
+            [],
             '',
             true,
             true,
             true,
-            array('doFetchMultiple')
+            ['doFetchMultiple']
         );
 
         $cache
             ->expects($this->once())
             ->method('doFetchMultiple')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 '[foo][1]' => 'bar',
                 '[bar][1]' => 'baz',
                 '[baz][1]' => 'tab',
-            )));
+            ]));
 
         $this->assertEquals(
-            array('foo' => 'bar', 'bar' => 'baz'),
-            $cache->fetchMultiple(array('foo', 'bar'))
+            ['foo' => 'bar', 'bar' => 'baz'],
+            $cache->fetchMultiple(['foo', 'bar'])
         );
     }
 
@@ -37,12 +37,12 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
         /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
         $cache = $this->getMockForAbstractClass(
             'Doctrine\Common\Cache\CacheProvider',
-            array(),
+            [],
             '',
             true,
             true,
             true,
-            array('doFetch', 'doSave', 'doContains')
+            ['doFetch', 'doSave', 'doContains']
         );
 
         $cache
@@ -75,12 +75,12 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
         /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
         $cache = $this->getMockForAbstractClass(
             'Doctrine\Common\Cache\CacheProvider',
-            array(),
+            [],
             '',
             true,
             true,
             true,
-            array('doSave')
+            ['doSave']
         );
 
         $cache
@@ -95,9 +95,9 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
             ->with('[kok][1]', 'vok', 0)
             ->will($this->returnValue(true));
 
-        $cache->saveMultiple(array(
+        $cache->saveMultiple([
             'kerr'  => 'verr',
             'kok'   => 'vok',
-        ));
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -67,7 +67,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache  = $this->_getCacheDriver();
         $values = $this->provideDataToCache();
-        $saved  = array();
+        $saved  = [];
 
         foreach ($values as $key => $value) {
             $cache->save($key, $value[0]);
@@ -88,7 +88,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             'Testing fetchMultiple with a single key'
         );
 
-        $keysWithNonExisting = array();
+        $keysWithNonExisting = [];
         $keysWithNonExisting[] = 'non_existing1';
         $keysWithNonExisting[] = $keys[0];
         $keysWithNonExisting[] = 'non_existing2';
@@ -106,7 +106,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
-        $this->assertSame(array(), $cache->fetchMultiple(array()));
+        $this->assertSame([], $cache->fetchMultiple([]));
     }
 
     public function testSaveMultiple()
@@ -134,25 +134,25 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $obj2->obj = $obj;
         $obj->obj2 = $obj2;
 
-        return array(
-            'array' => array(array('one', 2, 3.01)),
-            'string' => array('value'),
-            'string_invalid_utf8' => array("\xc3\x28"),
-            'string_null_byte' => array('with'."\0".'null char'),
-            'integer' => array(1),
-            'float' => array(1.5),
-            'object' => array(new ArrayObject(array('one', 2, 3.01))),
-            'object_recursive' => array($obj),
-            'true' => array(true),
+        return [
+            'array' => [['one', 2, 3.01]],
+            'string' => ['value'],
+            'string_invalid_utf8' => ["\xc3\x28"],
+            'string_null_byte' => ['with'."\0".'null char'],
+            'integer' => [1],
+            'float' => [1.5],
+            'object' => [new ArrayObject(['one', 2, 3.01])],
+            'object_recursive' => [$obj],
+            'true' => [true],
             // the following are considered FALSE in boolean context, but caches should still recognize their existence
-            'null' => array(null),
-            'false' => array(false),
-            'array_empty' => array(array()),
-            'string_zero' => array('0'),
-            'integer_zero' => array(0),
-            'float_zero' => array(0.0),
-            'string_empty' => array(''),
-        );
+            'null' => [null],
+            'false' => [false],
+            'array_empty' => [[]],
+            'string_zero' => ['0'],
+            'integer_zero' => [0],
+            'float_zero' => [0.0],
+            'string_empty' => [''],
+        ];
     }
 
     public function testDeleteIsSuccessfulWhenKeyDoesNotExist()
@@ -222,34 +222,34 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
      */
     public function provideCacheIds()
     {
-        return array(
-            array(':'),
-            array('\\'),
-            array('/'),
-            array('<'),
-            array('>'),
-            array('"'),
-            array('*'),
-            array('?'),
-            array('|'),
-            array('['),
-            array(']'),
-            array('ä'),
-            array('a'),
-            array('é'),
-            array('e'),
-            array('.'), // directory traversal
-            array('..'), // directory traversal
-            array('-'),
-            array('_'),
-            array('$'),
-            array('%'),
-            array(' '),
-            array("\0"),
-            array(''),
-            array(str_repeat('a', 300)), // long key
-            array(str_repeat('a', 113)),
-        );
+        return [
+            [':'],
+            ['\\'],
+            ['/'],
+            ['<'],
+            ['>'],
+            ['"'],
+            ['*'],
+            ['?'],
+            ['|'],
+            ['['],
+            [']'],
+            ['ä'],
+            ['a'],
+            ['é'],
+            ['e'],
+            ['.'], // directory traversal
+            ['..'], // directory traversal
+            ['-'],
+            ['_'],
+            ['$'],
+            ['%'],
+            [' '],
+            ["\0"],
+            [''],
+            [str_repeat('a', 300)], // long key
+            [str_repeat('a', 113)],
+        ];
     }
 
     public function testLifetime()

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -9,7 +9,7 @@ class ChainCacheTest extends CacheTest
 {
     protected function _getCacheDriver()
     {
-        return new ChainCache(array(new ArrayCache()));
+        return new ChainCache([new ArrayCache()]);
     }
 
     public function testLifetime()
@@ -32,7 +32,7 @@ class ChainCacheTest extends CacheTest
 
         $cache2->expects($this->never())->method('doFetch');
 
-        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache = new ChainCache([$cache1, $cache2]);
         $chainCache->save('id', 'bar');
 
         $this->assertEquals('bar', $chainCache->fetch('id'));
@@ -45,7 +45,7 @@ class ChainCacheTest extends CacheTest
 
         $cache2->save('bar', 'value');
 
-        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache = new ChainCache([$cache1, $cache2]);
 
         $this->assertFalse($cache1->contains('bar'));
 
@@ -60,7 +60,7 @@ class ChainCacheTest extends CacheTest
         $cache1 = new ArrayCache();
         $cache2 = new ArrayCache();
 
-        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache = new ChainCache([$cache1, $cache2]);
         $chainCache->setNamespace('bar');
 
         $this->assertEquals('bar', $cache1->getNamespace());
@@ -75,7 +75,7 @@ class ChainCacheTest extends CacheTest
         $cache1->expects($this->once())->method('doDelete');
         $cache2->expects($this->once())->method('doDelete');
 
-        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache = new ChainCache([$cache1, $cache2]);
         $chainCache->delete('bar');
     }
 
@@ -87,7 +87,7 @@ class ChainCacheTest extends CacheTest
         $cache1->expects($this->once())->method('doFlush');
         $cache2->expects($this->once())->method('doFlush');
 
-        $chainCache = new ChainCache(array($cache1, $cache2));
+        $chainCache = new ChainCache([$cache1, $cache2]);
         $chainCache->flushAll();
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -18,8 +18,8 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $this->driver = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array(), '', false
+            ['doFetch', 'doContains', 'doSave'],
+            [], '', false
         );
     }
 
@@ -28,9 +28,9 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         $cache          = $this->driver;
         $method         = new \ReflectionMethod($cache, 'getFilename');
         $key            = 'item-key';
-        $expectedDir    = array(
+        $expectedDir    = [
             '84',
-        );
+        ];
         $expectedDir    = implode(DIRECTORY_SEPARATOR, $expectedDir);
 
         $method->setAccessible(true);
@@ -45,13 +45,13 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $driver1 = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array(__DIR__, '.*')
+            ['doFetch', 'doContains', 'doSave'],
+            [__DIR__, '.*']
         );
         $driver2 = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array(__DIR__, '.php')
+            ['doFetch', 'doContains', 'doSave'],
+            [__DIR__, '.php']
         );
 
         $doGetStats = new \ReflectionMethod($driver1, 'doGetStats');
@@ -72,8 +72,8 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $driver = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array(__DIR__ . '/../', DIRECTORY_SEPARATOR . basename(__FILE__))
+            ['doFetch', 'doContains', 'doSave'],
+            [__DIR__ . '/../', DIRECTORY_SEPARATOR . basename(__FILE__)]
         );
 
         $doGetStats = new \ReflectionMethod($driver, 'doGetStats');
@@ -91,8 +91,8 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
 
         $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array('', '', 'invalid')
+            ['doFetch', 'doContains', 'doSave'],
+            ['', '', 'invalid']
         );
     }
 
@@ -101,8 +101,8 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         $directory = __DIR__ . '/../';
         $driver = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array($directory)
+            ['doFetch', 'doContains', 'doSave'],
+            [$directory]
         );
 
         $doGetDirectory = new \ReflectionMethod($driver, 'getDirectory');
@@ -119,8 +119,8 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         $extension = DIRECTORY_SEPARATOR . basename(__FILE__);
         $driver = $this->getMock(
             'Doctrine\Common\Cache\FileCache',
-            array('doFetch', 'doContains', 'doSave'),
-            array($directory, $extension)
+            ['doFetch', 'doContains', 'doSave'],
+            [$directory, $extension]
         );
 
         $doGetExtension = new \ReflectionMethod($driver, 'getExtension');
@@ -188,7 +188,7 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
             . '_' . $keyHash
             . '.doctrine.cache';
 
-        return array($key, $keyPath, $hashedKeyPath);
+        return [$key, $keyPath, $hashedKeyPath];
     }
 
     public function getPathLengthsToTest()
@@ -196,12 +196,12 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
         // Windows officially supports 260 bytes including null terminator
         // 259 characters is too large due to PHP bug (https://bugs.php.net/bug.php?id=70943)
         // 260 characters is too large - null terminator is included in allowable length
-        return array(
-            array(257, false),
-            array(258, false),
-            array(259, true),
-            array(260, true)
-        );
+        return [
+            [257, false],
+            [258, false],
+            [259, true],
+            [260, true]
+        ];
     }
 
     /**
@@ -220,7 +220,7 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
 
         $fileCache = $this->getMockForAbstractClass(
             'Doctrine\Common\Cache\FileCache',
-            array($basePath, '.doctrine.cache')
+            [$basePath, '.doctrine.cache']
         );
 
         list($key, $keyPath, $hashedKeyPath) = $this->getKeyAndPathFittingLength($length);

--- a/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
@@ -52,7 +52,7 @@ class MongoDBCacheTest extends CacheTest
     public function testMongoCursorExceptionsDoNotBubbleUp()
     {
         /* @var $collection \MongoCollection|\PHPUnit_Framework_MockObject_MockObject */
-        $collection = $this->getMock('MongoCollection', array(), array(), '', false);
+        $collection = $this->getMock('MongoCollection', [], [], '', false);
 
         $collection->expects(self::once())->method('update')->willThrowException(new \MongoCursorException());
 

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -25,7 +25,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
         $cache = $this->_getCacheDriver();
 
         // Test save
-        $cache->save('test_set_state', new SetStateClass(array(1,2,3)));
+        $cache->save('test_set_state', new SetStateClass([1,2,3]));
 
         //Test __set_state call
         $this->assertCount(0, SetStateClass::$values);
@@ -33,7 +33,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
         // Test fetch
         $value = $cache->fetch('test_set_state');
         $this->assertInstanceOf('Doctrine\Tests\Common\Cache\SetStateClass', $value);
-        $this->assertEquals(array(1,2,3), $value->getValue());
+        $this->assertEquals([1,2,3], $value->getValue());
 
         //Test __set_state call
         $this->assertCount(1, SetStateClass::$values);
@@ -47,7 +47,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
         $cache = $this->_getCacheDriver();
 
         $this->setExpectedException('InvalidArgumentException');
-        $cache->save('test_not_set_state', new NotSetStateClass(array(1,2,3)));
+        $cache->save('test_not_set_state', new NotSetStateClass([1,2,3]));
     }
 
     public function testGetStats()
@@ -85,7 +85,7 @@ class NotSetStateClass
 
 class SetStateClass extends NotSetStateClass
 {
-    public static $values = array();
+    public static $values = [];
 
     public static function __set_state($data)
     {

--- a/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
@@ -50,7 +50,7 @@ class PredisCacheTest extends CacheTest
      */
     public function testSetContainsFetchDelete($value)
     {
-        if (array() === $value) {
+        if ([] === $value) {
             $this->markTestIncomplete(
                 'Predis currently doesn\'t support saving empty array values. '
                 . 'See https://github.com/nrk/predis/issues/241'
@@ -67,7 +67,7 @@ class PredisCacheTest extends CacheTest
      */
     public function testUpdateExistingEntry($value)
     {
-        if (array() === $value) {
+        if ([] === $value) {
             $this->markTestIncomplete(
                 'Predis currently doesn\'t support saving empty array values. '
                 . 'See https://github.com/nrk/predis/issues/241'


### PR DESCRIPTION
This PR

* [x] uses short array syntax

💁 Ran

```
$ composer global require friendsofphp/php-cs-fixer:2.0.0-alpha
$ php-cs-fixer fix --using-cache=no --rules=short_array_syntax .
```