### PR TITLE
Fix: Remove assignment from condition

### DIFF
--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -86,11 +86,13 @@ class SQLite3Cache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        if ($item = $this->findById($id)) {
-            return unserialize($item[self::DATA_FIELD]);
+        $item = $this->findById($id)
+
+        if (!$item) {
+            return false;
         }
 
-        return false;
+        return unserialize($item[self::DATA_FIELD]);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes an assignment from a condition

💁 This also makes the happy path more obvious! We're happier if we found something in the cache, aren't we?