### PR TITLE
Save first namespace cache key

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -209,7 +209,12 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         }
 
         $namespaceCacheKey = $this->getNamespaceCacheKey();
-        $this->namespaceVersion = $this->doFetch($namespaceCacheKey) ?: 1;
+        $this->namespaceVersion = $this->doFetch($namespaceCacheKey);
+
+        if (!$this->namespaceVersion) {
+            $this->namespaceVersion = 1;
+            $this->doSave($namespaceCacheKey, 1);
+        }
 
         return $this->namespaceVersion;
     }


### PR DESCRIPTION
By not saving the "1" namespace, the CacheProvider generates a cache miss at almost each instantiation. Saving this "1" namespace turns this miss into a hit, and thus allows to benefit from the fastest cache when using a ChainCache.