### PR TITLE
Fix bug with not installed igbinary extension

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -170,6 +170,11 @@ class RedisCache extends CacheProvider
         if (defined('HHVM_VERSION')) {
             return Redis::SERIALIZER_PHP;
         }
-        return defined('Redis::SERIALIZER_IGBINARY') ? Redis::SERIALIZER_IGBINARY : Redis::SERIALIZER_PHP;
+
+        if (defined('Redis::SERIALIZER_IGBINARY') && extension_loaded('igbinary')) {
+            return Redis::SERIALIZER_IGBINARY;
+        }
+
+        return Redis::SERIALIZER_PHP;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -35,6 +35,18 @@ class RedisCacheTest extends CacheTest
         $this->assertInstanceOf('Redis', $this->_getCacheDriver()->getRedis());
     }
 
+    public function testSerializerOptionWithOutIgbinaryExtension()
+    {
+        if (defined('Redis::SERIALIZER_IGBINARY') && extension_loaded('igbinary')) {
+            $this->markTestSkipped('Extension igbinary is loaded.');
+        }
+
+        $this->assertEquals(
+            \Redis::SERIALIZER_PHP,
+            $this->_getCacheDriver()->getRedis()->getOption(\Redis::OPT_SERIALIZER)
+        );
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Please review and merge my pull request. If You want reproduce this is bug, You can install php-redis extension without recommends packages (php-igbinary) and write any data to Redis cache, thats all. Thanks.