### PR TITLE
Allow Redis Serializer option to be set outside

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -44,7 +44,11 @@ class RedisCache extends CacheProvider
      */
     public function setRedis(Redis $redis)
     {
-        $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
+        // The redis object is injected from an external service
+        // Serializer option should be set outside
+        // We should not force the serializer option here
+        // This code is left here for reference only
+//        $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
         $this->redis = $redis;
     }
 


### PR DESCRIPTION
The RedisCache Adapter should not force Serializer Option.
The Serializer Option should be set When the redis client
is created (outside of the scope of this class).
