### PR TITLE
Fix - #148 - cache provider should reject negative TTLs

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -117,7 +117,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         }
 
         if ($lifetime < 0) {
-            throw LifeTimeException::fromNegativeValue();
+            throw LifeTimeException::fromNegativeLifetime();
         }
 
         $namespacedKeysAndValues = [];
@@ -148,7 +148,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         }
 
         if ($lifeTime < 0) {
-            throw LifeTimeException::fromNegativeValue();
+            throw LifeTimeException::fromNegativeLifetime();
         }
 
         return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -113,7 +113,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     public function saveMultiple(array $keysAndValues, $lifetime = 0)
     {
         if (! is_int($lifetime)) {
-            throw LifeTimeException::fromWrongTypeValue($lifetime);
+            throw LifeTimeException::fromNonIntegerLifetime($lifetime);
         }
 
         if ($lifetime < 0) {
@@ -144,7 +144,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     public function save($id, $data, $lifeTime = 0)
     {
         if (! is_int($lifeTime)) {
-            throw LifeTimeException::fromWrongTypeValue($lifeTime);
+            throw LifeTimeException::fromNonIntegerLifetime($lifeTime);
         }
 
         if ($lifeTime < 0) {

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\Common\Cache;
 
+use Doctrine\Common\Cache\Exception\LifeTimeException;
+
 /**
  * Base class for cache provider implementations.
  *
@@ -110,8 +112,12 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function saveMultiple(array $keysAndValues, $lifetime = 0)
     {
+        if (! is_int($lifetime)) {
+            throw LifeTimeException::fromWrongTypeValue($lifetime);
+        }
+
         if ($lifetime < 0) {
-            throw new \RuntimeException('Cannot assign a negative value as $lifetime');
+            throw LifeTimeException::fromNegativeValue();
         }
 
         $namespacedKeysAndValues = [];
@@ -133,12 +139,16 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     /**
      * {@inheritdoc}
      *
-     * @throws \RuntimeException
+     * @throws \Doctrine\Common\Cache\Exception\LifeTimeException
      */
     public function save($id, $data, $lifeTime = 0)
     {
+        if (! is_int($lifeTime)) {
+            throw LifeTimeException::fromWrongTypeValue($lifeTime);
+        }
+
         if ($lifeTime < 0) {
-            throw new \RuntimeException('Cannot assign a negative value as $lifeTime');
+            throw LifeTimeException::fromNegativeValue();
         }
 
         return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -105,15 +105,21 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \RuntimeException
      */
     public function saveMultiple(array $keysAndValues, $lifetime = 0)
     {
+        if ($lifetime < 0) {
+            throw new \RuntimeException('Cannot assign a negative value as $lifetime');
+        }
+
         $namespacedKeysAndValues = [];
         foreach ($keysAndValues as $key => $value) {
             $namespacedKeysAndValues[$this->getNamespacedId($key)] = $value;
         }
 
-        return $this->doSaveMultiple($namespacedKeysAndValues, max($lifetime, 0));
+        return $this->doSaveMultiple($namespacedKeysAndValues, $lifetime);
     }
 
     /**
@@ -126,10 +132,16 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \RuntimeException
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        return $this->doSave($this->getNamespacedId($id), $data, max($lifeTime, 0));
+        if ($lifeTime < 0) {
+            throw new \RuntimeException('Cannot assign a negative value as $lifeTime');
+        }
+
+        return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -112,7 +112,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function saveMultiple(array $keysAndValues, $lifetime = 0)
     {
-        if (! is_int($lifetime)) {
+        if (! is_numeric($lifetime)) {
             throw LifeTimeException::fromNonIntegerLifetime($lifetime);
         }
 
@@ -143,7 +143,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        if (! is_int($lifeTime)) {
+        if (! is_numeric($lifeTime)) {
             throw LifeTimeException::fromNonIntegerLifetime($lifeTime);
         }
 

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -113,7 +113,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
             $namespacedKeysAndValues[$this->getNamespacedId($key)] = $value;
         }
 
-        return $this->doSaveMultiple($namespacedKeysAndValues, $lifetime);
+        return $this->doSaveMultiple($namespacedKeysAndValues, max($lifetime, 0));
     }
 
     /**
@@ -129,7 +129,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        return $this->doSave($this->getNamespacedId($id), $data, $lifeTime);
+        return $this->doSave($this->getNamespacedId($id), $data, max($lifeTime, 0));
     }
 
     /**
@@ -256,7 +256,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      *
      * @param array $keysAndValues  Array of keys and values to save in cache
      * @param int   $lifetime       The lifetime. If != 0, sets a specific lifetime for these
-     *                              cache entries (0 => infinite lifeTime).
+     *                              cache entries (0 => infinite lifeTime). Is always an unsigned integer
      *
      * @return bool TRUE if the operation was successful, FALSE if it wasn't.
      */
@@ -279,7 +279,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      * @param string $id       The cache id.
      * @param string $data     The cache entry/data.
      * @param int    $lifeTime The lifetime. If != 0, sets a specific lifetime for this
-     *                           cache entry (0 => infinite lifeTime).
+     *                           cache entry (0 => infinite lifeTime). Is always an unsigned integer
      *
      * @return bool TRUE if the entry was successfully stored in the cache, FALSE otherwise.
      */

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -28,7 +28,7 @@ namespace Doctrine\Common\Cache\Exception;
  */
 class LifeTimeException extends \RuntimeException
 {
-    public static function fromWrongTypeValue($value)
+    public static function fromNonIntegerLifetime($value)
     {
         return new self(sprintf('$lifetime should be an integer, %s given', gettype($value)));
     }

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -30,11 +30,11 @@ class LifeTimeException extends \RuntimeException
 {
     public static function fromNonIntegerLifetime($value)
     {
-        return new self(sprintf('$lifetime should be an integer, %s given', gettype($value)));
+        return new self(sprintf('Lifetime should be an integer, %s given', gettype($value)));
     }
 
     public static function fromNegativeValue()
     {
-        return new self('Cannot assign a negative value as $lifeTime');
+        return new self('Cannot assign a negative value as LifeTime');
     }
 }

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -23,7 +23,7 @@ namespace Doctrine\Common\Cache\Exception;
  * Life Time Exception.
  *
  * @link   www.doctrine-project.org
- * @since  2.0
+ * @since  1.7
  * @author Jefersson Nathan <malukenho@phpse.net>
  */
 class LifeTimeException extends \RuntimeException

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache\Exception;
+
+/**
+ * Life Time Exception.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Jefersson Nathan <malukenho@phpse.net>
+ */
+class LifeTimeException extends \RuntimeException
+{
+    public static function fromWrongTypeValue($value)
+    {
+        return new self(sprintf('$lifetime should be an integer, %s given', gettype($value)));
+    }
+
+    public static function fromNegativeValue()
+    {
+        return new self('Cannot assign a negative value as $lifeTime');
+    }
+}

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -35,6 +35,6 @@ class LifeTimeException extends \RuntimeException
 
     public static function fromNegativeLifetime()
     {
-        return new self('Cannot assign a negative value as LifeTime');
+        return new self('Cannot assign a negative value as lifetime');
     }
 }

--- a/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
+++ b/lib/Doctrine/Common/Cache/Exception/LifeTimeException.php
@@ -33,7 +33,7 @@ class LifeTimeException extends \RuntimeException
         return new self(sprintf('Lifetime should be an integer, %s given', gettype($value)));
     }
 
-    public static function fromNegativeValue()
+    public static function fromNegativeLifetime()
     {
         return new self('Cannot assign a negative value as LifeTime');
     }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -88,14 +88,14 @@ class RedisCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doSaveMultiple(array $keysAndValues, $lifetime = 0)
+    protected function doSaveMultiple(array $keysAndValues, $lifeTime = 0)
     {
-        if ($lifetime) {
+        if ($lifeTime) {
             $success = true;
 
             // Keys have lifetime, use SETEX for each of them
             foreach ($keysAndValues as $key => $value) {
-                if (!$this->redis->setex($key, $lifetime, $value)) {
+                if (!$this->redis->setex($key, $lifeTime, $value)) {
                     $success = false;
                 }
             }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -90,7 +90,7 @@ class RedisCache extends CacheProvider
      */
     protected function doSaveMultiple(array $keysAndValues, $lifeTime = 0)
     {
-        if ($lifeTime > 0) {
+        if ($lifeTime) {
             $success = true;
 
             // Keys have lifetime, use SETEX for each of them

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -90,7 +90,7 @@ class RedisCache extends CacheProvider
      */
     protected function doSaveMultiple(array $keysAndValues, $lifeTime = 0)
     {
-        if ($lifeTime) {
+        if ($lifeTime > 0) {
             $success = true;
 
             // Keys have lifetime, use SETEX for each of them

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -307,7 +307,6 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             [[]],
             [true],
             [false],
-            [3e10]
         ];
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -125,6 +125,27 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertEquals($data, $cache->fetchMultiple($keys));
     }
 
+    /**
+     * When a negative TTL is passed in, it should be considered as 0
+     *
+     * @group #148
+     */
+    public function testSaveMultipleWithNegativeTtl()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->deleteAll();
+
+        $data = array_map(function ($value) {
+            return $value[0];
+        }, $this->provideDataToCache());
+
+        $this->assertTrue($cache->saveMultiple($data, -100));
+
+        $keys = array_keys($data);
+
+        $this->assertEquals($data, $cache->fetchMultiple($keys));
+    }
+
     public function provideDataToCache()
     {
         $obj = new \stdClass();

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -292,6 +292,20 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($cache->contains('noexpire'), 'Data with lifetime of zero should not expire');
     }
 
+    /**
+     * When a negative TTL is passed in, it should be considered as 0
+     *
+     * @group #148
+     */
+    public function testNoExpireWithNegativeTtl()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('noexpire', 'value', -100);
+        // @TODO should more TTL-based tests pop up, so then we should mock the `time` API instead
+        sleep(1);
+        $this->assertTrue($cache->contains('noexpire'), 'Data with negative lifetime should not expire');
+    }
+
     public function testLongLifetime()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Common\Cache;
 
 use Doctrine\Common\Cache\Cache;
 use ArrayObject;
+use Doctrine\Common\Cache\Exception\LifeTimeException;
 
 abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
 {
@@ -29,7 +30,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
-        $this->setExpectedException('Doctrine\Common\Cache\Exception\LifeTimeException');
+        $this->setExpectedException(LifeTimeException::class);
 
         $cache->save('id', 'data', $lifeTime);
     }
@@ -166,7 +167,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             return $value[0];
         }, $this->provideDataToCache());
 
-        $this->setExpectedException('RunTimeException');
+        $this->setExpectedException(LifeTimeException::class);
 
         $this->assertTrue($cache->saveMultiple($data, -100));
     }
@@ -338,7 +339,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
-        $this->setExpectedException('Doctrine\Common\Cache\Exception\LifeTimeException');
+        $this->setExpectedException(LifeTimeException::class);
 
         $cache->save('noexpire', 'value', -100);
     }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -338,7 +338,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     {
         $cache = $this->_getCacheDriver();
 
-        $this->setExpectedException('RuntimeException');
+        $this->setExpectedException('Doctrine\Common\Cache\Exception\LifeTimeException');
 
         $cache->save('noexpire', 'value', -100);
     }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -7,6 +7,21 @@ use ArrayObject;
 
 abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
 {
+    public function testSetNameSpace()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $cache->setNamespace('Foo');
+
+        $this->assertSame('Foo', $cache->getNamespace());
+        $this->assertInternalType('string', $cache->getNamespace());
+
+        $cache->setNamespace(123456);
+
+        $this->assertSame('123456', $cache->getNamespace());
+        $this->assertInternalType('string', $cache->getNamespace());
+    }
+
     /**
      * @dataProvider provideDataToCache
      */
@@ -139,11 +154,9 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             return $value[0];
         }, $this->provideDataToCache());
 
+        $this->setExpectedException('RunTimeException');
+
         $this->assertTrue($cache->saveMultiple($data, -100));
-
-        $keys = array_keys($data);
-
-        $this->assertEquals($data, $cache->fetchMultiple($keys));
     }
 
     public function provideDataToCache()
@@ -300,10 +313,10 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     public function testNoExpireWithNegativeTtl()
     {
         $cache = $this->_getCacheDriver();
+
+        $this->setExpectedException('RuntimeException');
+
         $cache->save('noexpire', 'value', -100);
-        // @TODO should more TTL-based tests pop up, so then we should mock the `time` API instead
-        sleep(1);
-        $this->assertTrue($cache->contains('noexpire'), 'Data with negative lifetime should not expire');
     }
 
     public function testLongLifetime()

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -23,6 +23,18 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     }
 
     /**
+     * @dataProvider providerNonIntegerLifeTime
+     */
+    public function testLifeTimeShouldBeAnIntegerValue($lifeTime)
+    {
+        $cache = $this->_getCacheDriver();
+
+        $this->setExpectedException('Doctrine\Common\Cache\Exception\LifeTimeException');
+
+        $cache->save('id', 'data', $lifeTime);
+    }
+
+    /**
      * @dataProvider provideDataToCache
      */
     public function testSetContainsFetchDelete($value)
@@ -283,6 +295,18 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
             [''],
             [str_repeat('a', 300)], // long key
             [str_repeat('a', 113)],
+        ];
+    }
+
+    public function providerNonIntegerLifeTime()
+    {
+        return [
+            ['string'],
+            [new \StdClass],
+            [[]],
+            [true],
+            [false],
+            [3e10]
         ];
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/Exception/LifeTimeExceptionTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Exception/LifeTimeExceptionTest.php
@@ -23,7 +23,7 @@ class LifeTimeExceptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(LifeTimeException::class, $exception);
         $this->assertSame(
-            'Cannot assign a negative value as LifeTime',
+            'Cannot assign a negative value as lifetime',
             $exception->getMessage()
         );
     }

--- a/tests/Doctrine/Tests/Common/Cache/Exception/LifeTimeExceptionTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Exception/LifeTimeExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache\Exception;
+
+use Doctrine\Common\Cache\Exception\LifeTimeException;
+
+class LifeTimeExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromNonIntegerLifetime()
+    {
+        $exception = LifeTimeException::fromNonIntegerLifetime('foo');
+
+        $this->assertInstanceOf(LifeTimeException::class, $exception);
+        $this->assertSame(
+            'Lifetime should be an integer, string given',
+            $exception->getMessage()
+        );
+    }
+
+    public function testFromNegativeLifetime()
+    {
+        $exception = LifeTimeException::fromNegativeLifetime();
+
+        $this->assertInstanceOf(LifeTimeException::class, $exception);
+        $this->assertSame(
+            'Cannot assign a negative value as LifeTime',
+            $exception->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Continuation of #148

This is a possible BC break for scenarios in which the consumer of the API explicitly used negative TTLs.

The current patch silently turns negative integers into `0` internally, but I'm not happy with it.

I changed the docblock documentation so that an unsigned integer is required. What do you folks think about throwing an exception instead of silently turning negatives into `0`? Too much of a breakage?
