### PR TITLE
Fix - #152 #147 - silence failed file access attempts in file based caches

### DIFF
--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -30,11 +30,21 @@ class PhpFileCache extends FileCache
     const EXTENSION = '.doctrinecache.php';
 
     /**
+     * @var callable
+     *
+     * This is cached in a local static variable to avoid instantiating a closure each time we need an empty handler
+     */
+    private static $emptyErrorHandler;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct($directory, $extension = self::EXTENSION, $umask = 0002)
     {
         parent::__construct($directory, $extension, $umask);
+
+        self::$emptyErrorHandler = function () {
+        };
     }
 
     /**
@@ -108,7 +118,11 @@ class PhpFileCache extends FileCache
     {
         $fileName = $this->getFilename($id);
 
-        $value = file_exists($fileName) ? @include $fileName : null;
+        set_error_handler(self::$emptyErrorHandler);
+
+        $value = @include $fileName;
+
+        restore_error_handler();
 
         if (! isset($value['lifetime'])) {
             return false;

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -118,9 +118,10 @@ class PhpFileCache extends FileCache
     {
         $fileName = $this->getFilename($id);
 
+        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
         set_error_handler(self::$emptyErrorHandler);
 
-        $value = @include $fileName;
+        $value = include $fileName;
 
         restore_error_handler();
 

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -108,8 +108,7 @@ class PhpFileCache extends FileCache
     {
         $fileName = $this->getFilename($id);
 
-        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
-        $value = file_exists($fileName) ? include $fileName : null;
+        $value = file_exists($fileName) ? @include $fileName : null;
 
         if (! isset($value['lifetime'])) {
             return false;

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -109,7 +109,7 @@ class PhpFileCache extends FileCache
         $fileName = $this->getFilename($id);
 
         // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
-        $value = @include $fileName;
+        $value = file_exists($fileName) ? include $fileName : null;
 
         if (! isset($value['lifetime'])) {
             return false;

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -444,6 +444,10 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($cache->save('with_ttl', 'with_ttl', 3600));
     }
 
+    /**
+     * @group 147
+     * @group 152
+     */
     public function testFetchingANonExistingKeyShouldNeverCauseANoticeOrWarning()
     {
         $cache = $this->_getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -444,6 +444,31 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($cache->save('with_ttl', 'with_ttl', 3600));
     }
 
+    public function testFetchingANonExistingKeyShouldNeverCauseANoticeOrWarning()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $errorHandler = function () {
+            restore_error_handler();
+
+            $this->fail('include failure captured');
+        };
+
+        set_error_handler($errorHandler);
+
+        $cache->fetch('key');
+
+        self::assertSame(
+            $errorHandler,
+            set_error_handler(function () {
+            }),
+            'The error handler is the one set by this test, and wasn\'t replaced'
+        );
+
+        restore_error_handler();
+        restore_error_handler();
+    }
+
     /**
      * Return whether multiple cache providers share the same storage.
      *

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -66,6 +66,17 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         return new PhpFileCache($this->directory);
     }
+
+    public function testFailureOnIncludeNotSettedCacheDoesntGetCaughtAsError()
+    {
+        $cache = $this->_getCacheDriver();
+        set_error_handler(function($errno, $errstr, $errfile, $errlin){
+            exit('Oops '.$errstr);
+        });
+        $cache->fetch('key');
+
+        restore_error_handler();
+    }
 }
 
 class NotSetStateClass

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -70,7 +70,8 @@ class PhpFileCacheTest extends BaseFileCacheTest
     public function testFailureOnIncludeNotSettedCacheDoesntGetCaughtAsError()
     {
         $cache = $this->_getCacheDriver();
-        set_error_handler(function($errno, $errstr, $errfile, $errlin){
+        set_error_handler(function($errno, $errstr, $errfile, $errline){
+            restore_error_handler();
             $this->fail('include failure captured');
         });
         $cache->fetch('key');

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -71,7 +71,7 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         $cache = $this->_getCacheDriver();
         set_error_handler(function($errno, $errstr, $errfile, $errlin){
-            exit('Oops '.$errstr);
+            $this->fail('include failure captured');
         });
         $cache->fetch('key');
 

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -66,18 +66,6 @@ class PhpFileCacheTest extends BaseFileCacheTest
     {
         return new PhpFileCache($this->directory);
     }
-
-    public function testFailureOnIncludeNotSettedCacheDoesntGetCaughtAsError()
-    {
-        $cache = $this->_getCacheDriver();
-        set_error_handler(function($errno, $errstr, $errfile, $errline){
-            restore_error_handler();
-            $this->fail('include failure captured');
-        });
-        $cache->fetch('key');
-
-        restore_error_handler();
-    }
 }
 
 class NotSetStateClass


### PR DESCRIPTION
Continues #152
Fixes #147 

This is moved to `1.7.0` only, since some people my have been relying on the error handlers.