### PR TITLE
CacheProvider : store the namespaceVersion on first get

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -209,7 +209,10 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         }
 
         $namespaceCacheKey = $this->getNamespaceCacheKey();
-        $this->namespaceVersion = $this->doFetch($namespaceCacheKey) ?: 1;
+        if (false === $this->namespaceVersion = $this->doFetch($namespaceCacheKey)) {
+            $this->namespaceVersion = 1;
+            $this->doSave($namespaceCacheKey, $this->namespaceVersion);
+        };
 
         return $this->namespaceVersion;
     }


### PR DESCRIPTION
Isn't it faster to hit the namespaceVersion than miss it evry time ?