### PR TITLE
Fix temp file rights on shared storage

### DIFF
--- a/lib/Doctrine/Common/Cache/FileCache.php
+++ b/lib/Doctrine/Common/Cache/FileCache.php
@@ -252,6 +252,7 @@ abstract class FileCache extends CacheProvider
         @chmod($tmpFile, 0666 & (~$this->umask));
 
         if (file_put_contents($tmpFile, $content) !== false) {
+            @chmod($tmpFile, 0666 & (~$this->umask));
             if (@rename($tmpFile, $filename)) {
                 return true;
             }


### PR DESCRIPTION
It is apparently necessary to set the rights of the file both
before and after writing it. Depending if you write the file on a
shared storage or not.