### PR TITLE
Disable PHPUnit feature @runInSeparateProcess 

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -219,7 +219,6 @@ class FileCacheTest extends \Doctrine\Tests\DoctrineTestCase
     }
 
     /**
-     * @runInSeparateProcess
      * @dataProvider getPathLengthsToTest
      *
      * @covers \Doctrine\Common\Cache\FileCache::getFilename


### PR DESCRIPTION
Hi.

PHPUnit feature @runInSeparateProcess cannot work properly if some extensions are not available.

Step by step:
* include tests/travis/php.ini into php config
* run php7.0 `php --interactive`, you will see error/errors:

`Warning: PHP Startup: Unable to load dynamic library '...php-7.0.13/lib/php/extensions/no-debug-non-zts-20151012/mongo.so' - dlopen(...php-7.0.13/lib/php/extensions/no-debug-non-zts-20151012/mongo.so, 9): image not found in Unknown on line 0`

* now run phpunit - test set is failed
* if you remove @runInSeparateProcess  - pass!