### PR TITLE
Allow setting namespace version as well.

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -50,14 +50,15 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     /**
      * Sets the namespace to prefix all cache ids with.
      *
-     * @param string $namespace
+     * @param string       $namespace
+     * @param null|integer $version
      *
      * @return void
      */
-    public function setNamespace($namespace)
+    public function setNamespace($namespace, $version = null)
     {
         $this->namespace        = (string) $namespace;
-        $this->namespaceVersion = null;
+        $this->namespaceVersion = $version;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -44,12 +44,12 @@ class ChainCache extends CacheProvider
     /**
      * {@inheritDoc}
      */
-    public function setNamespace($namespace)
+    public function setNamespace($namespace, $version = null)
     {
-        parent::setNamespace($namespace);
+        parent::setNamespace($namespace, $version);
 
         foreach ($this->cacheProviders as $cacheProvider) {
-            $cacheProvider->setNamespace($namespace);
+            $cacheProvider->setNamespace($namespace, $version);
         }
     }
 


### PR DESCRIPTION
I'm deploying almost all my projects with there own cache (memcache/redis/etc.).
Therefor I do not run into problems with collisions on keys (and so do not need the prefix/namespace from the cache layer of Doctrine).
This also means I do not need to know which keys are in use by my project when I want to flush them all out.

Another method we use is setting the prefix directly on the cache (for example the short commit hash). In this case we always know the namespace we want to use and the version (always 1 (or some other magic number)).

This PR will allow people to create cache providers that can be tweaked in handling the namespace and version. It makes it possible to use the cache without a [single round trip](https://github.com/doctrine/cache/blob/1.6.x/lib/Doctrine/Common/Cache/CacheProvider.php#L212) to fetch the version of the namespace before using the cache.

For example when using this patched version we config the following cache provider:
```php

// bootstrap.php

$app->register(new GeckoPackages\Silex\Services\Caching\MemcachedServiceProvider(), [
    'memcache.prefix' => $commitHash,
    'memcache.enable_log' => $app['debug'],
]);

// [...]

$app['orm'] = function (Application $app) {
    $config = Setup::createAnnotationMetadataConfiguration(
        [__DIR__.'/../Entities'],
        $app['debug']
    );
    
    $cacheDriver = new class extends \Doctrine\Common\Cache\MemcachedCache {
        public function setNamespace($namespace, $version = null)
        {
            parent::setNamespace('', 1);
        }

        public function deleteAll()
        {
            $this->doFlush();
        }
    };

    $cacheDriver->setMemcached($app['memcache']);
    $cacheDriver->setNamespace('', 1);

    $config->setHydrationCacheImpl($cacheDriver);
    $config->setSecondLevelCacheEnabled(true);

    $factory = new \Doctrine\ORM\Cache\DefaultCacheFactory(
        new RegionsConfiguration(),
        $cacheDriver
    );

    $cacheConfig = $config->getSecondLevelCacheConfiguration();
    $cacheConfig->setCacheFactory($factory);
    if ($app['debug']) {
        $cacheConfig->setCacheLogger(new Doctrine\ORM\Cache\Logging\StatisticsCacheLogger());
    }

    $regionConfig = $cacheConfig->getRegionsConfiguration();
    $regionConfig->setDefaultLifetime(9000);

    $em = EntityManager::create($app['db'], $config);
    $em->getEventManager()->addEventSubscriber(
        new OrmEventLogger(
            $em,
            function (AbstractTrackableEntry $entry, $property, $value) {
                return 'rememberMe' !== $property;
            }
        )
    );

    return $em;
};
```