### PR TITLE
Fixes #206 - BashoRiakCache uses native PHP Riak client; deprecate RiakCache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpunit/phpunit": "^6.3",
         "predis/predis":   "~1.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "doctrine/coding-standard": "^1.0"
+        "doctrine/coding-standard": "^1.0",
+        "basho/riak":      "^3.3.0"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "predis/predis":   "~1.0",
         "squizlabs/php_codesniffer": "^3.0",
         "doctrine/coding-standard": "^1.0",
-        "basho/riak":      "^3.3.0"
+        "basho/riak":      "^3.4.0"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"

--- a/lib/Doctrine/Common/Cache/BashoRiakCache.php
+++ b/lib/Doctrine/Common/Cache/BashoRiakCache.php
@@ -28,7 +28,7 @@ use Basho\Riak\Object;
  * Riak cache provider.
  *
  * @link   www.doctrine-project.org
- * @since  1.7
+ * @since  1.7.2
  * @author Anthon Pang <apang@softwaredevelopment.ca>
  */
 class BashoRiakCache extends CacheProvider
@@ -87,13 +87,13 @@ class BashoRiakCache extends CacheProvider
                 : $response->getObject();
 
             // Check for expired object
-            if ($this->isExpired($object)) {
+            if ($object && $this->isExpired($object)) {
                 try {
                     $command = (new Command\Builder\DeleteObject($this->riak))
                         ->buildLocation($id, $this->bucketName)
                         ->build();
 
-                    $response = $command->execute();
+                    $command->execute();
                 } catch (RiakException $e) {
                     // Do nothing
                 }
@@ -134,13 +134,13 @@ class BashoRiakCache extends CacheProvider
             $object = $response->getObject();
 
             // Check for expired object
-            if ($this->isExpired($object)) {
+            if ($object && $this->isExpired($object)) {
                 try {
                     $command = (new Command\Builder\DeleteObject($this->riak))
                         ->buildLocation($id, $this->bucketName)
                         ->build();
 
-                    $response = $command->execute();
+                    $command->execute();
                 } catch (RiakException $e) {
                     // Do nothing
                 }
@@ -174,7 +174,7 @@ class BashoRiakCache extends CacheProvider
                 $object->setMetaDataValue(self::EXPIRES_HEADER, (string) (time() + $lifeTime));
             }
 
-            $response = $command->execute();
+            $command->execute();
 
             return true;
         } catch (RiakException $e) {
@@ -196,7 +196,7 @@ class BashoRiakCache extends CacheProvider
                 ->buildLocation($id, $this->bucketName)
                 ->build();
 
-            $response = $command->execute();
+            $command->execute();
 
             return true;
         } catch (RiakException $e) {
@@ -231,7 +231,7 @@ class BashoRiakCache extends CacheProvider
                         ->atLocation($location)
                         ->build();
 
-                    $response = $command->execute();
+                    $command->execute();
                 } catch (RiakException $e) {
                     // Do nothing
                 }
@@ -261,8 +261,6 @@ class BashoRiakCache extends CacheProvider
         } catch (RiakException $e) {
             // Do nothing
         }
-
-        return false;
     }
 
     /**
@@ -299,7 +297,7 @@ class BashoRiakCache extends CacheProvider
      * @param string   $expires
      * @param Object[] $objectList
      *
-     * @return \Basho\Riak\Object
+     * @return \Basho\Riak\Object|null
      */
     protected function resolveConflict($id, $vClock, $expires, array $objectList)
     {
@@ -319,11 +317,11 @@ class BashoRiakCache extends CacheProvider
                 $mergedObject->setMetaDataValue(self::EXPIRES_HEADER, $expires);
             }
 
-            $response = $command->execute();
+            $command->execute();
+
+            return $mergedObject;
         } catch (RiakException $e) {
             // Do nothing
         }
-
-        return $mergedObject;
     }
 }

--- a/lib/Doctrine/Common/Cache/BashoRiakCache.php
+++ b/lib/Doctrine/Common/Cache/BashoRiakCache.php
@@ -1,0 +1,332 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+use Basho\Riak;
+use Basho\Riak\Command;
+use Basho\Riak\Exception as RiakException;
+use Basho\Riak\Object;
+
+/**
+ * Riak cache provider.
+ *
+ * @link   www.doctrine-project.org
+ * @since  1.7
+ * @author Anthon Pang <apang@softwaredevelopment.ca>
+ */
+class BashoRiakCache extends CacheProvider
+{
+    const EXPIRES_HEADER = 'X-Riak-Meta-Expires';
+
+    /**
+     * @var \Basho\Riak
+     */
+    private $riak;
+
+    /**
+     * @var string
+     */
+    private $bucketName;
+
+    /**
+     * Sets the riak bucket instance to use.
+     *
+     * @param \Basho\Riak $riak
+     * @param string      $bucketName
+     */
+    public function __construct(Riak $riak, $bucketName)
+    {
+        $this->riak = $riak;
+        $this->bucketName = $bucketName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        $id = urlencode($id);
+
+        try {
+            $command = (new Command\Builder\FetchObject($this->riak))
+                ->buildLocation($id, $this->bucketName)
+                ->build();
+
+            $response = $command->execute();
+
+            // No objects found
+            if ($response->isNotFound()) {
+                return false;
+            }
+
+            // Check for attempted siblings
+            $object = ($response->hasSiblings())
+                ? $this->resolveConflict($id, $response->getObject()->getVclock(), $response->getSiblings())
+                : $response->getObject();
+
+            // Check for expired object
+            if ($this->isExpired($object)) {
+                try {
+                    $command = (new Command\Builder\DeleteObject($this->riak))
+                        ->buildLocation($id, $this->bucketName)
+                        ->build();
+
+                    $response = $command->execute();
+                } catch (RiakException $e) {
+                    // Do nothing
+                }
+
+                return false;
+            }
+
+            return unserialize($response->getObject()->getData());
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        $id = urlencode($id);
+
+        try {
+            // We only need the HEAD, not the entire object
+            // ... unfortunately, the API doesn't provide a HEAD method yet
+            $command = (new Command\Builder\FetchObject($this->riak))
+                ->buildLocation($id, $this->bucketName)
+                ->build();
+
+            $response = $command->execute();
+
+            // No objects found
+            if ($response->isNotFound()) {
+                return false;
+            }
+
+            // Check for attempted siblings
+            $object = $response->getObject();
+
+            // Check for expired object
+            if ($this->isExpired($object)) {
+                try {
+                    $command = (new Command\Builder\DeleteObject($this->riak))
+                        ->buildLocation($id, $this->bucketName)
+                        ->build();
+
+                    $response = $command->execute();
+                } catch (RiakException $e) {
+                    // Do nothing
+                }
+
+                return false;
+            }
+
+            return true;
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        $id = urlencode($id);
+
+        try {
+            $command = (new Command\Builder\StoreObject($this->riak))
+                ->buildObject(serialize($data))
+                ->buildLocation($id, $this->bucketName)
+                ->build();
+
+            if ($lifeTime > 0) {
+                $object = $command->getObject();
+                $object->setMetaDataValue(self::EXPIRES_HEADER, (string) (time() + $lifeTime));
+            }
+
+            $response = $command->execute();
+
+            return true;
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        $id = urlencode($id);
+
+        try {
+            $command = (new Command\Builder\DeleteObject($this->riak))
+                ->buildLocation($id, $this->bucketName)
+                ->build();
+
+            $response = $command->execute();
+
+            return true;
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        try {
+            $command = (new Command\Builder\ListObjects($this->riak))
+                ->buildBucket($this->bucketName)
+                ->build();
+
+            $response = $command->execute();
+
+            if ($response->isNotFound()) {
+                return false;
+            }
+
+            $data = $response->getObject()->getData();
+
+            if ( ! count($data->keys)) {
+                return false;
+            }
+
+            foreach ($data->keys as $id) {
+                $id = urlencode($id);
+
+                try {
+                    $command = (new Command\Builder\DeleteObject($this->riak))
+                        ->buildLocation($id, $this->bucketName)
+                        ->build();
+
+                    $response = $command->execute();
+                } catch (RiakException $e) {
+                    // Do nothing
+                }
+            }
+
+            return true;
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        // Only exposed through HTTP stats API, not Protocol Buffers API
+        try {
+            $command = (new Command\Builder\FetchStats($this->riak))
+                ->build();
+
+            $response = $command->execute();
+
+            return $response->getAllStats();
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a given Riak Object have expired.
+     *
+     * @param \Basho\Riak\Object $object
+     *
+     * @return bool
+     */
+    private function isExpired(Object $object)
+    {
+        $metadataMap = $object->getMetadata();
+
+        return isset($metadataMap[self::EXPIRES_HEADER])
+            && $metadataMap[self::EXPIRES_HEADER] < time();
+    }
+
+    /**
+     * On-read conflict resolution. Applied approach here is last write wins.
+     * Specific needs may override this method to apply alternate conflict resolutions.
+     *
+     * {@internal Riak does not attempt to resolve a write conflict, and store
+     * it as sibling of conflicted one. By following this approach, it is up to
+     * the next read to resolve the conflict. When this happens, your fetched
+     * object will have a list of siblings (read as a list of objects).
+     * In our specific case, we do not care about the intermediate ones since
+     * they are all the same read from storage, and we do apply a last sibling
+     * (last write) wins logic.
+     * If by any means our resolution generates another conflict, it'll up to
+     * next read to properly solve it.}
+     *
+     * @param string   $id
+     * @param string   $vClock
+     * @param Object[] $objectList
+     *
+     * @return \Basho\Riak\Object
+     */
+    protected function resolveConflict($id, $vClock, array $objectList)
+    {
+        // Our approach here is last-write wins
+        $winner = $objectList[count($objectList) - 1];
+
+        try {
+            $command = (new Command\Builder\StoreObject($this->riak))
+                ->buildObject(serialize($winner->getData()))
+                ->buildLocation($id, $this->bucketName)
+                ->build();
+
+            $mergedObject = $command->getObject();
+
+            $expires = $winner->getObject()->getMetaDataValue(self::EXPIRES_HEADER);
+
+            if ($expires) {
+                $mergedObject->setMetaDataValue(self::EXPIRES_HEADER, $expires);
+                $mergedObject->setVclock($vClock);
+            }
+
+            $response = $command->execute();
+
+            return true;
+        } catch (RiakException $e) {
+            // Do nothing
+        }
+
+        return $mergedObject;
+    }
+}

--- a/lib/Doctrine/Common/Cache/BashoRiakCache.php
+++ b/lib/Doctrine/Common/Cache/BashoRiakCache.php
@@ -214,6 +214,7 @@ class BashoRiakCache extends CacheProvider
         try {
             $command = (new Command\Builder\ListObjects($this->riak))
                 ->buildBucket($this->bucketName)
+                ->acknowledgeRisk(true)
                 ->build();
 
             $response = $command->execute();
@@ -222,18 +223,12 @@ class BashoRiakCache extends CacheProvider
                 return false;
             }
 
-            $data = $response->getObject()->getData();
+            $keys = $response->getKeys();
 
-            if ( ! count($data->keys)) {
-                return false;
-            }
-
-            foreach ($data->keys as $id) {
-                $id = urlencode($id);
-
+            foreach ($keys as $location) {
                 try {
                     $command = (new Command\Builder\DeleteObject($this->riak))
-                        ->buildLocation($id, $this->bucketName)
+                        ->atLocation($location)
                         ->build();
 
                     $response = $command->execute();

--- a/lib/Doctrine/Common/Cache/BashoRiakCache.php
+++ b/lib/Doctrine/Common/Cache/BashoRiakCache.php
@@ -296,8 +296,8 @@ class BashoRiakCache extends CacheProvider
      * In our specific case, we do not care about the intermediate ones since
      * they are all the same read from storage, and we do apply a last sibling
      * (last write) wins logic.
-     * If by any means our resolution generates another conflict, it'll up to
-     * next read to properly solve it.}
+     * If by any means our resolution generates another conflict, it'll be up to
+     * the next read to properly solve it.}
      *
      * @param string   $id
      * @param string   $vClock

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -30,6 +30,8 @@ use Riak\Object;
  * @link   www.doctrine-project.org
  * @since  1.1
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ *
+ * @deprecated
  */
 class RiakCache extends CacheProvider
 {

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -224,8 +224,8 @@ class RiakCache extends CacheProvider
      * In our specific case, we do not care about the intermediate ones since
      * they are all the same read from storage, and we do apply a last sibling
      * (last write) wins logic.
-     * If by any means our resolution generates another conflict, it'll up to
-     * next read to properly solve it.}
+     * If by any means our resolution generates another conflict, it'll be up to
+     * the next read to properly solve it.}
      *
      * @param string $id
      * @param string $vClock

--- a/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\Common\Cache;
 use Basho\Riak;
 use Basho\Riak\Exception as RiakException;
 use Basho\Riak\Node;
-use Basho\Riak\Object;
+use Basho\Riak\Object as BashoRiakObject;
 use Doctrine\Common\Cache\BashoRiakCache;
 
 /**
@@ -44,7 +44,7 @@ class BashoRiakCacheTest extends CacheTest
     /**
      * {@inheritdoc}
      */
-    public function testGetStats()
+    public function testGetStats() : void
     {
         $cache = $this->_getCacheDriver();
         $stats = $cache->getStats();
@@ -65,7 +65,7 @@ class BashoRiakCacheTest extends CacheTest
         $id = '1';
         $vClock = 'a';
         $expires = (string) (time() + 5);
-        $objectList = [new Object('a'), new Object('b')];
+        $objectList = [new BashoRiakObject('a'), new BashoRiakObject('b')];
 
         $object = $reflection->invoke($cache, $id, $vClock, $expires, $objectList);
 
@@ -78,7 +78,7 @@ class BashoRiakCacheTest extends CacheTest
      *
      * @return \Doctrine\Common\Cache\BashoRiakCache
      */
-    protected function _getCacheDriver()
+    protected function _getCacheDriver() : CacheProvider
     {
         return new BashoRiakCache($this->riak, $this->namespace);
     }

--- a/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Basho\Riak;
+use Basho\Riak\Command;
+use Basho\Riak\Exception as RiakException;
+use Basho\Riak\Node;
+use Doctrine\Common\Cache\BashoRiakCache;
+
+/**
+ * BashoRiakCache test
+ *
+ * @group Riak
+ * @requires basho/riak
+ */
+class BashoRiakCacheTest extends CacheTest
+{
+    /**
+     * @var \Basho\Riak
+     */
+    private $riak;
+
+    /**
+     * @var \Basho\Riak\Command
+     */
+    private $command;
+
+    protected function setUp()
+    {
+        try {
+            $node = (new Node\Builder)
+                ->atHost('127.0.0.1')
+                ->onPort(8098)
+                ->build();
+
+            $this->riak = new Riak([$node]);
+            $this->namespace = 'test';
+        } catch (RiakException $e) {
+            $this->markTestSkipped('Cannot connect to Riak.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testGetStats()
+    {
+        $cache = $this->_getCacheDriver();
+        $stats = $cache->getStats();
+
+        $this->assertTrue(is_array($stats) && count($stats) > 0);
+    }
+
+    /**
+     * Retrieve BashoRiakCache instance.
+     *
+     * @return \Doctrine\Common\Cache\BashoRiakCache
+     */
+    protected function _getCacheDriver()
+    {
+        return new BashoRiakCache($this->riak, $this->namespace);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/BashoRiakCacheTest.php
@@ -3,9 +3,9 @@
 namespace Doctrine\Tests\Common\Cache;
 
 use Basho\Riak;
-use Basho\Riak\Command;
 use Basho\Riak\Exception as RiakException;
 use Basho\Riak\Node;
+use Basho\Riak\Object;
 use Doctrine\Common\Cache\BashoRiakCache;
 
 /**
@@ -50,6 +50,27 @@ class BashoRiakCacheTest extends CacheTest
         $stats = $cache->getStats();
 
         $this->assertTrue(is_array($stats) && count($stats) > 0);
+    }
+
+    /**
+     * @link https://github.com/doctrine/cache/pull/215
+     */
+    public function testResolveConflict()
+    {
+        $cache = $this->_getCacheDriver();
+
+        $reflection = new \ReflectionMethod(BashoRiakCache::class, 'resolveConflict');
+        $reflection->setAccessible(true);
+
+        $id = '1';
+        $vClock = 'a';
+        $expires = (string) (time() + 5);
+        $objectList = [new Object('a'), new Object('b')];
+
+        $object = $reflection->invoke($cache, $id, $vClock, $expires, $objectList);
+
+        $this->assertTrue($object !== null);
+        $this->assertEquals('b', unserialize($object->getData()));
     }
 
     /**


### PR DESCRIPTION
Commits squashed.

Note: this PR is dependent on https://github.com/basho/riak-php-client/pull/148
