### PR TITLE
Combine multi operation interfaces into a single one

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -30,7 +30,7 @@ namespace Doctrine\Common\Cache;
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  * @author Benoit Burnichon <bburnichon@gmail.com>
  */
-abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, MultiGetCache, MultiPutCache, MultiDeleteCache
+abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, MultiOperationCache
 {
     const DOCTRINE_NAMESPACE_CACHEKEY = 'DoctrineNamespaceCacheKey[%s]';
 

--- a/lib/Doctrine/Common/Cache/MultiGetCache.php
+++ b/lib/Doctrine/Common/Cache/MultiGetCache.php
@@ -25,6 +25,8 @@ namespace Doctrine\Common\Cache;
  * @link   www.doctrine-project.org
  * @since  1.4
  * @author Asmir Mustafic <goetas@gmail.com>
+ *
+ * @deprecated
  */
 interface MultiGetCache
 {

--- a/lib/Doctrine/Common/Cache/MultiOperationCache.php
+++ b/lib/Doctrine/Common/Cache/MultiOperationCache.php
@@ -20,22 +20,12 @@
 namespace Doctrine\Common\Cache;
 
 /**
- * Interface for cache drivers that allows to put many items at once.
+ * Interface for cache drivers that supports multiple items manipulation.
  *
  * @link   www.doctrine-project.org
  * @since  1.7
- * @author Benoit Burnichon <bburnichon@gmail.com>
- *
- * @deprecated
+ * @author Luís Cobucci <lcobucci@gmail.com>
  */
-interface MultiDeleteCache
+interface MultiOperationCache extends MultiGetCache, MultiDeleteCache, MultiPutCache
 {
-    /**
-     * Deletes several cache entries.
-     *
-     * @param string[] $keys Array of keys to delete from cache
-     *
-     * @return bool TRUE if the operation was successful, FALSE if it wasn't.
-     */
-    function deleteMultiple(array $keys);
 }

--- a/lib/Doctrine/Common/Cache/MultiPutCache.php
+++ b/lib/Doctrine/Common/Cache/MultiPutCache.php
@@ -25,6 +25,8 @@ namespace Doctrine\Common\Cache;
  * @link   www.doctrine-project.org
  * @since  1.6
  * @author Daniel Gorgan <danut007ro@gmail.com>
+ *
+ * @deprecated
  */
 interface MultiPutCache
 {


### PR DESCRIPTION
Since we always depend on the three interfaces there's no reason to segregate them.

And that's also important to be able to implement https://github.com/doctrine/doctrine2/issues/6241