### PR TITLE
Redis: Remove useless ifdef for HHVM

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -175,10 +175,6 @@ class RedisCache extends CacheProvider
      */
     protected function getSerializerValue()
     {
-        if (defined('HHVM_VERSION')) {
-            return Redis::SERIALIZER_PHP;
-        }
-
         if (defined('Redis::SERIALIZER_IGBINARY') && extension_loaded('igbinary')) {
             return Redis::SERIALIZER_IGBINARY;
         }


### PR DESCRIPTION
That condition is no longer needed, it was added in past to fix tests when extension_loaded('igbinary') piece didn't exist yet