### PR TITLE
Run APCu and APC on PHP 7.x too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ services:
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then pecl channel-update pecl.php.net; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 7.* ]]; then pecl install riak-beta; fi;
-    - if [[ $TRAVIS_PHP_VERSION = '5.6' ]] ; then echo yes | pecl install apcu-4.0.10; fi;
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
+    - if [[ $TRAVIS_PHP_VERSION = '5.6' ]] ; then echo yes | pecl install apcu-4.0.11; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl upgrade apcu apcu_bc-beta; fi;
+    - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then phpenv config-add ./tests/travis/php-5.ini; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then phpenv config-add ./tests/travis/php-7.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/travis/php.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then PHPUNIT_FLAGS="--coverage-clover clover.xml"; fi
 

--- a/tests/travis/php-5.ini
+++ b/tests/travis/php-5.ini
@@ -1,0 +1,2 @@
+extension="mongo.so"
+extension="memcache.so"

--- a/tests/travis/php-7.ini
+++ b/tests/travis/php-7.ini
@@ -1,0 +1,2 @@
+extension="apcu.so"
+extension="apc.so"

--- a/tests/travis/php.ini
+++ b/tests/travis/php.ini
@@ -1,5 +1,3 @@
-extension="mongo.so"
-extension="memcache.so"
 extension="memcached.so"
 extension="redis.so"
 


### PR DESCRIPTION
APC(u) tests are being skipped for PHP 7.x and they shouldn't (IMO)