### PR TITLE
Create expiration index when getting expired entry

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MongoDBCacheTest.php
@@ -68,6 +68,17 @@ class MongoDBCacheTest extends CacheTest
         self::assertFalse($cache->save('foo', 'bar'));
     }
 
+    public function testLifetime() : void
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('expire', 'value', 1);
+        $this->assertCount(1, $this->collection->getIndexInfo());
+        $this->assertTrue($cache->contains('expire'), 'Data should not be expired yet');
+        sleep(2);
+        $this->assertFalse($cache->contains('expire'), 'Data should be expired');
+        $this->assertCount(2, $this->collection->getIndexInfo());
+    }
+
     protected function _getCacheDriver() : CacheProvider
     {
         return new MongoDBCache($this->collection);


### PR DESCRIPTION
Fixes #139, Supersedes #140.

Instead of always creating the index on class instantiation, this solution only creates the index once per process and only if receiving an expired cache entry (indicating that the index hasn't been properly created). Overrides the lifetime test case to test index creation. My machine didn't quite remove expired entries exactly at their expiration time, so I excluded that from the test case.