### PR TITLE
Add cache provider for ext-mongodb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,12 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
+        "mongodb/mongodb": "^1.1",
         "phpunit/phpunit": "^5.7",
         "predis/predis":   "~1.0"
     },
     "suggest": {
-        "alcaeus/mongo-php-adapter": "Required to use MongoDB driver"
+        "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
     },
     "conflict": {
         "doctrine/common": ">2.2,<2.4"

--- a/lib/Doctrine/Common/Cache/ExtMongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/ExtMongoDBCache.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection;
+use MongoDB\Database;
+use MongoDB\Driver\Exception\Exception;
+use MongoDB\Model\BSONDocument;
+
+/**
+ * MongoDB cache provider for ext-mongodb
+ *
+ * @internal Do not use - will be removed in 2.0. Use MongoDBCache instead
+ */
+class ExtMongoDBCache extends CacheProvider
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    /**
+     * @var bool
+     */
+    private $expirationIndexCreated = false;
+
+    /**
+     * Constructor.
+     *
+     * This provider will default to the write concern and read preference
+     * options set on the Database instance (or inherited from MongoDB or
+     * Client). Using an unacknowledged write concern (< 1) may make the return
+     * values of delete() and save() unreliable. Reading from secondaries may
+     * make contain() and fetch() unreliable.
+     *
+     * @see http://www.php.net/manual/en/mongo.readpreferences.php
+     * @see http://www.php.net/manual/en/mongo.writeconcerns.php
+     * @param Collection $collection
+     */
+    public function __construct(Collection $collection)
+    {
+        // Ensure there is no typemap set - we want to use our own
+        $this->collection = $collection->withOptions(['typeMap' => null]);
+        $this->database = new Database($collection->getManager(), $collection->getDatabaseName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        $document = $this->collection->findOne(['_id' => $id], [MongoDBCache::DATA_FIELD, MongoDBCache::EXPIRATION_FIELD]);
+
+        if ($document === null) {
+            return false;
+        }
+
+        if ($this->isExpired($document)) {
+            $this->createExpirationIndex();
+            $this->doDelete($id);
+            return false;
+        }
+
+        return unserialize($document[MongoDBCache::DATA_FIELD]->getData());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        $document = $this->collection->findOne(['_id' => $id], [MongoDBCache::EXPIRATION_FIELD]);
+
+        if ($document === null) {
+            return false;
+        }
+
+        if ($this->isExpired($document)) {
+            $this->createExpirationIndex();
+            $this->doDelete($id);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        try {
+            $this->collection->updateOne(
+                ['_id' => $id],
+                ['$set' => [
+                    MongoDBCache::EXPIRATION_FIELD => ($lifeTime > 0 ? new UTCDateTime((time() + $lifeTime) * 1000): null),
+                    MongoDBCache::DATA_FIELD => new Binary(serialize($data), Binary::TYPE_GENERIC),
+                ]],
+                ['upsert' => true]
+            );
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        try {
+            $this->collection->deleteOne(['_id' => $id]);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        try {
+            // Use remove() in lieu of drop() to maintain any collection indexes
+            $this->collection->deleteMany([]);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        $uptime = null;
+        $memoryUsage = null;
+
+        try {
+            $serverStatus = $this->database->command([
+                'serverStatus' => 1,
+                'locks' => 0,
+                'metrics' => 0,
+                'recordStats' => 0,
+                'repl' => 0,
+            ])->toArray()[0];
+            $uptime = $serverStatus['uptime'] ?? null;
+        } catch (Exception $e) {
+        }
+
+        try {
+            $collStats = $this->database->command(['collStats' => $this->collection->getCollectionName()])->toArray()[0];
+            $memoryUsage = $collStats['size'] ?? null;
+        } catch (Exception $e) {
+        }
+
+        return [
+            Cache::STATS_HITS => null,
+            Cache::STATS_MISSES => null,
+            Cache::STATS_UPTIME => $uptime,
+            Cache::STATS_MEMORY_USAGE => $memoryUsage,
+            Cache::STATS_MEMORY_AVAILABLE  => null,
+        ];
+    }
+
+    /**
+     * Check if the document is expired.
+     *
+     * @param BSONDocument $document
+     *
+     * @return bool
+     */
+    private function isExpired(BSONDocument $document): bool
+    {
+        return isset($document[MongoDBCache::EXPIRATION_FIELD]) &&
+            $document[MongoDBCache::EXPIRATION_FIELD] instanceof UTCDateTime &&
+            $document[MongoDBCache::EXPIRATION_FIELD]->toDateTime() < new \DateTime();
+    }
+
+    private function createExpirationIndex(): void
+    {
+        if ($this->expirationIndexCreated) {
+            return;
+        }
+
+        $this->collection->createIndex([MongoDBCache::EXPIRATION_FIELD => 1], ['background' => true, 'expireAfterSeconds' => 0]);
+    }
+}

--- a/lib/Doctrine/Common/Cache/LegacyMongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/LegacyMongoDBCache.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+use MongoBinData;
+use MongoCollection;
+use MongoCursorException;
+use MongoDate;
+
+/**
+ * MongoDB cache provider.
+ *
+ * @author Jeremy Mikola <jmikola@gmail.com>
+ * @internal Do not use - will be removed in 2.0. Use MongoDBCache instead
+ */
+class LegacyMongoDBCache extends CacheProvider
+{
+    /**
+     * @var MongoCollection
+     */
+    private $collection;
+
+    /**
+     * @var bool
+     */
+    private $expirationIndexCreated = false;
+
+    /**
+     * Constructor.
+     *
+     * This provider will default to the write concern and read preference
+     * options set on the MongoCollection instance (or inherited from MongoDB or
+     * MongoClient). Using an unacknowledged write concern (< 1) may make the
+     * return values of delete() and save() unreliable. Reading from secondaries
+     * may make contain() and fetch() unreliable.
+     *
+     * @see http://www.php.net/manual/en/mongo.readpreferences.php
+     * @see http://www.php.net/manual/en/mongo.writeconcerns.php
+     * @param MongoCollection $collection
+     */
+    public function __construct(MongoCollection $collection)
+    {
+        @trigger_error('Using the legacy MongoDB cache provider is deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+        $this->collection = $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        $document = $this->collection->findOne(['_id' => $id], [MongoDBCache::DATA_FIELD, MongoDBCache::EXPIRATION_FIELD]);
+
+        if ($document === null) {
+            return false;
+        }
+
+        if ($this->isExpired($document)) {
+            $this->createExpirationIndex();
+            $this->doDelete($id);
+            return false;
+        }
+
+        return unserialize($document[MongoDBCache::DATA_FIELD]->bin);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        $document = $this->collection->findOne(['_id' => $id], [MongoDBCache::EXPIRATION_FIELD]);
+
+        if ($document === null) {
+            return false;
+        }
+
+        if ($this->isExpired($document)) {
+            $this->createExpirationIndex();
+            $this->doDelete($id);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        try {
+            $result = $this->collection->update(
+                ['_id' => $id],
+                ['$set' => [
+                    MongoDBCache::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
+                    MongoDBCache::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
+                ]],
+                ['upsert' => true, 'multiple' => false]
+            );
+        } catch (MongoCursorException $e) {
+            return false;
+        }
+
+        return ($result['ok'] ?? 1) == 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        $result = $this->collection->remove(['_id' => $id]);
+
+        return ($result['ok'] ?? 1) == 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        // Use remove() in lieu of drop() to maintain any collection indexes
+        $result = $this->collection->remove();
+
+        return ($result['ok'] ?? 1) == 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        $serverStatus = $this->collection->db->command([
+            'serverStatus' => 1,
+            'locks' => 0,
+            'metrics' => 0,
+            'recordStats' => 0,
+            'repl' => 0,
+        ]);
+
+        $collStats = $this->collection->db->command(['collStats' => 1]);
+
+        return [
+            Cache::STATS_HITS => null,
+            Cache::STATS_MISSES => null,
+            Cache::STATS_UPTIME => $serverStatus['uptime'] ?? null,
+            Cache::STATS_MEMORY_USAGE => $collStats['size'] ?? null,
+            Cache::STATS_MEMORY_AVAILABLE  => null,
+        ];
+    }
+
+    /**
+     * Check if the document is expired.
+     *
+     * @param array $document
+     *
+     * @return bool
+     */
+    private function isExpired(array $document) : bool
+    {
+        return isset($document[MongoDBCache::EXPIRATION_FIELD]) &&
+            $document[MongoDBCache::EXPIRATION_FIELD] instanceof MongoDate &&
+            $document[MongoDBCache::EXPIRATION_FIELD]->sec < time();
+    }
+
+
+    private function createExpirationIndex(): void
+    {
+        if ($this->expirationIndexCreated) {
+            return;
+        }
+
+        $this->expirationIndexCreated = true;
+        $this->collection->createIndex([MongoDBCache::EXPIRATION_FIELD => 1], ['background' => true, 'expireAfterSeconds' => 0]);
+    }
+}

--- a/lib/Doctrine/Common/Cache/MongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/MongoDBCache.php
@@ -19,10 +19,8 @@
 
 namespace Doctrine\Common\Cache;
 
-use MongoBinData;
 use MongoCollection;
-use MongoCursorException;
-use MongoDate;
+use MongoDB\Collection;
 
 /**
  * MongoDB cache provider.
@@ -55,31 +53,33 @@ class MongoDBCache extends CacheProvider
     const EXPIRATION_FIELD = 'e';
 
     /**
-     * @var MongoCollection
+     * @var CacheProvider
      */
-    private $collection;
-
-    /**
-     * @var bool
-     */
-    private $expirationIndexCreated = false;
+    private $provider;
 
     /**
      * Constructor.
      *
      * This provider will default to the write concern and read preference
-     * options set on the MongoCollection instance (or inherited from MongoDB or
+     * options set on the collection instance (or inherited from MongoDB or
      * MongoClient). Using an unacknowledged write concern (< 1) may make the
      * return values of delete() and save() unreliable. Reading from secondaries
      * may make contain() and fetch() unreliable.
      *
      * @see http://www.php.net/manual/en/mongo.readpreferences.php
      * @see http://www.php.net/manual/en/mongo.writeconcerns.php
-     * @param MongoCollection $collection
+     * @param MongoCollection|Collection $collection
      */
-    public function __construct(MongoCollection $collection)
+    public function __construct($collection)
     {
-        $this->collection = $collection;
+        if ($collection instanceof MongoCollection) {
+            @trigger_error('Using a MongoCollection instance for creating a cache adapter is deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+            $this->provider = new LegacyMongoDBCache($collection);
+        } elseif ($collection instanceof Collection) {
+            $this->provider = new ExtMongoDBCache($collection);
+        } else {
+            throw new \InvalidArgumentException('Invalid collection given - expected a MongoCollection or MongoDB\Collection instance');
+        }
     }
 
     /**
@@ -87,19 +87,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        $document = $this->collection->findOne(['_id' => $id], [self::DATA_FIELD, self::EXPIRATION_FIELD]);
-
-        if ($document === null) {
-            return false;
-        }
-
-        if ($this->isExpired($document)) {
-            $this->createExpirationIndex();
-            $this->doDelete($id);
-            return false;
-        }
-
-        return unserialize($document[self::DATA_FIELD]->bin);
+        return $this->provider->doFetch($id);
     }
 
     /**
@@ -107,19 +95,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        $document = $this->collection->findOne(['_id' => $id], [self::EXPIRATION_FIELD]);
-
-        if ($document === null) {
-            return false;
-        }
-
-        if ($this->isExpired($document)) {
-            $this->createExpirationIndex();
-            $this->doDelete($id);
-            return false;
-        }
-
-        return true;
+        return $this->provider->doContains($id);
     }
 
     /**
@@ -127,20 +103,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = 0)
     {
-        try {
-            $result = $this->collection->update(
-                ['_id' => $id],
-                ['$set' => [
-                    self::EXPIRATION_FIELD => ($lifeTime > 0 ? new MongoDate(time() + $lifeTime) : null),
-                    self::DATA_FIELD => new MongoBinData(serialize($data), MongoBinData::BYTE_ARRAY),
-                ]],
-                ['upsert' => true, 'multiple' => false]
-            );
-        } catch (MongoCursorException $e) {
-            return false;
-        }
-
-        return isset($result['ok']) ? $result['ok'] == 1 : true;
+        return $this->provider->doSave($id, $data, $lifeTime);
     }
 
     /**
@@ -148,9 +111,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        $result = $this->collection->remove(['_id' => $id]);
-
-        return isset($result['ok']) ? $result['ok'] == 1 : true;
+        return $this->provider->doDelete($id);
     }
 
     /**
@@ -158,10 +119,7 @@ class MongoDBCache extends CacheProvider
      */
     protected function doFlush()
     {
-        // Use remove() in lieu of drop() to maintain any collection indexes
-        $result = $this->collection->remove();
-
-        return isset($result['ok']) ? $result['ok'] == 1 : true;
+        return $this->provider->doFlush();
     }
 
     /**
@@ -169,46 +127,6 @@ class MongoDBCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        $serverStatus = $this->collection->db->command([
-            'serverStatus' => 1,
-            'locks' => 0,
-            'metrics' => 0,
-            'recordStats' => 0,
-            'repl' => 0,
-        ]);
-
-        $collStats = $this->collection->db->command(['collStats' => 1]);
-
-        return [
-            Cache::STATS_HITS => null,
-            Cache::STATS_MISSES => null,
-            Cache::STATS_UPTIME => (isset($serverStatus['uptime']) ? (int) $serverStatus['uptime'] : null),
-            Cache::STATS_MEMORY_USAGE => (isset($collStats['size']) ? (int) $collStats['size'] : null),
-            Cache::STATS_MEMORY_AVAILABLE  => null,
-        ];
-    }
-
-    /**
-     * Check if the document is expired.
-     *
-     * @param array $document
-     *
-     * @return bool
-     */
-    private function isExpired(array $document) : bool
-    {
-        return isset($document[self::EXPIRATION_FIELD]) &&
-            $document[self::EXPIRATION_FIELD] instanceof MongoDate &&
-            $document[self::EXPIRATION_FIELD]->sec < time();
-    }
-
-    private function createExpirationIndex(): void
-    {
-        if ($this->expirationIndexCreated) {
-            return;
-        }
-
-        $this->expirationIndexCreated = true;
-        $this->collection->createIndex([self::EXPIRATION_FIELD => 1], ['background' => true, 'expireAfterSeconds' => 0]);
+        return $this->provider->doGetStats();
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/ExtMongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ExtMongoDBCacheTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\MongoDBCache;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Driver\Exception\Exception;
+
+/**
+ * @requires extension mongodb
+ */
+class ExtMongoDBCacheTest extends CacheTest
+{
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    protected function setUp(): void
+    {
+        try {
+            $mongo = new Client();
+            $mongo->listDatabases();
+        } catch (Exception $e) {
+            $this->markTestSkipped('Cannot connect to MongoDB because of: ' . $e);
+        }
+
+        $this->collection = $mongo->selectCollection('doctrine_common_cache', 'test');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->collection instanceof Collection) {
+            $this->collection->drop();
+        }
+    }
+
+    public function testGetStats(): void
+    {
+        $cache = $this->_getCacheDriver();
+        // Run a query to create the collection
+        $this->collection->find([]);
+        $stats = $cache->getStats();
+
+        $this->assertNull($stats[Cache::STATS_HITS]);
+        $this->assertNull($stats[Cache::STATS_MISSES]);
+        $this->assertGreaterThan(0, $stats[Cache::STATS_UPTIME]);
+        $this->assertEquals(0, $stats[Cache::STATS_MEMORY_USAGE]);
+        $this->assertNull($stats[Cache::STATS_MEMORY_AVAILABLE]);
+    }
+
+    public function testLifetime() : void
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('expire', 'value', 1);
+        $this->assertCount(1, $this->collection->listIndexes());
+        $this->assertTrue($cache->contains('expire'), 'Data should not be expired yet');
+        sleep(2);
+        $this->assertFalse($cache->contains('expire'), 'Data should be expired');
+        $this->assertCount(2, $this->collection->listIndexes());
+    }
+
+    protected function _getCacheDriver(): CacheProvider
+    {
+        return new MongoDBCache($this->collection);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/LegacyMongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/LegacyMongoDBCacheTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Common\Cache;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\LegacyMongoDBCache;
 use Doctrine\Common\Cache\MongoDBCache;
 use MongoClient;
 use MongoCollection;
@@ -12,7 +13,7 @@ use MongoConnectionException;
 /**
  * @requires extension mongodb
  */
-class MongoDBCacheTest extends CacheTest
+class LegacyMongoDBCacheTest extends CacheTest
 {
     /**
      * @var MongoCollection
@@ -63,7 +64,7 @@ class MongoDBCacheTest extends CacheTest
 
         $collection->expects(self::once())->method('update')->willThrowException(new \MongoCursorException());
 
-        $cache = new MongoDBCache($collection);
+        $cache = new LegacyMongoDBCache($collection);
 
         self::assertFalse($cache->save('foo', 'bar'));
     }


### PR DESCRIPTION
Fixes #142.

Creates two new internal classes containing the actual logic, one for the legacy driver, one for ext-mongodb. The existing `MongoDBCache` class just proxies all calls to the correct implementation, depending on which collection class was given in the constructor. Since constructor arguments may change in extending classes, this shouldn't cause a BC break. With 2.0, `MongoDBNGCache` will be renamed `MongoDBCache` and the old classes removed to drop support for ext-mongo.