### PR TITLE
Redis: Set serialization option

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -36,14 +36,21 @@ class RedisCache extends CacheProvider
     private $redis;
 
     /**
+     * @var int|null
+     */
+    private $serializer;
+
+    /**
      * Sets the redis instance to use.
      *
      * @param Redis $redis
+     * @param int|null $serializer
      *
      * @return void
      */
-    public function setRedis(Redis $redis)
+    public function setRedis(Redis $redis, $serializer = null)
     {
+        $this->setSerializerValue($serializer);
         $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
         $this->redis = $redis;
     }
@@ -167,6 +174,16 @@ class RedisCache extends CacheProvider
     }
 
     /**
+     * Force a specific serializer constant to use.
+     *
+     * @param int $serializer
+     */
+    protected function setSerializerValue($serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    /**
      * Returns the serializer constant to use. If Redis is compiled with
      * igbinary support, that is used. Otherwise the default PHP serializer is
      * used.
@@ -175,6 +192,10 @@ class RedisCache extends CacheProvider
      */
     protected function getSerializerValue()
     {
+        if (null !== $this->serializer) {
+            return $this->serializer;
+        }
+
         if (defined('Redis::SERIALIZER_IGBINARY') && extension_loaded('igbinary')) {
             return Redis::SERIALIZER_IGBINARY;
         }

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -49,13 +49,23 @@ class RedisCacheTest extends CacheTest
         );
     }
 
+    public function testSettingExplicitlySerializerOption() : void
+    {
+        $driver = $this->_getCacheDriver(Redis::SERIALIZER_NONE);
+
+        $this->assertEquals(
+            Redis::SERIALIZER_NONE,
+            $driver->getRedis()->getOption(Redis::OPT_SERIALIZER)
+        );
+    }
+
     /**
      * {@inheritDoc}
      */
-    protected function _getCacheDriver() : CacheProvider
+    protected function _getCacheDriver($serializer = null) : CacheProvider
     {
         $driver = new RedisCache();
-        $driver->setRedis($this->_redis);
+        $driver->setRedis($this->_redis, $serializer);
         return $driver;
     }
 }


### PR DESCRIPTION
This pull request allows one to explicitly set the serializer that is going to be used by Redis when storing data.

We got hit by this when we upgraded to PHP 7.1 and the Redis extension pulled in igbinary extension as a dependency and all of the existing data stored in Redis was not recognized anymore. Not to mention that we reused the Redis connection for some Redis specific stuff as well and the serializer option was changed in those cases as well :(

I have a pull request for https://github.com/doctrine/DoctrineCacheBundle in the making but it depends on this one.