### PR TITLE
add support for ext-couchbase:^2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,14 @@ services:
     - mongodb
     - memcached
     - redis-server
+    - docker
 
 before_install:
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
     - echo yes | pecl upgrade apcu
     - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+    - ./tests/travis/Couchbase.sh
     - phpenv config-add ./tests/travis/php.ini
 
 install:

--- a/lib/Doctrine/Common/Cache/CouchbaseBucketCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseBucketCache.php
@@ -30,13 +30,13 @@ use Couchbase\Exception;
  */
 final class CouchbaseBucketCache extends CacheProvider
 {
-    private CONST MINIMUM_VERSION = '2.3.0';
+    private const MINIMUM_VERSION = '2.3.0';
 
-    private CONST KEY_NOT_FOUND = 13;
+    private const KEY_NOT_FOUND = 13;
 
-    private CONST MAX_KEY_LENGTH = 250;
+    private const MAX_KEY_LENGTH = 250;
 
-    private CONST THIRTY_DAYS_IN_SECONDS = 2592000;
+    private const THIRTY_DAYS_IN_SECONDS = 2592000;
 
     /**
      * @var Bucket
@@ -91,7 +91,7 @@ final class CouchbaseBucketCache extends CacheProvider
         }
 
         if ($document instanceof Document) {
-            return !$document->error;
+            return ! $document->error;
         }
 
         return false;
@@ -117,7 +117,7 @@ final class CouchbaseBucketCache extends CacheProvider
         }
 
         if ($document instanceof Document) {
-            return !$document->error;
+            return ! $document->error;
         }
 
         return false;
@@ -137,7 +137,7 @@ final class CouchbaseBucketCache extends CacheProvider
         }
 
         if ($document instanceof Document) {
-            return !$document->error;
+            return ! $document->error;
         }
 
         return false;
@@ -170,10 +170,10 @@ final class CouchbaseBucketCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        $manager = $this->bucket->manager();
-        $stats   = $manager->info();
-        $nodes = $stats['nodes'];
-        $node = $nodes[0];
+        $manager          = $this->bucket->manager();
+        $stats            = $manager->info();
+        $nodes            = $stats['nodes'];
+        $node             = $nodes[0];
         $interestingStats = $node['interestingStats'];
 
         return [

--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -27,6 +27,8 @@ use \Couchbase;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Michael Nitschinger <michael@nitschinger.at>
+ * @deprecated Couchbase SDK 1.x is now deprecated. Use \Doctrine\Common\Cache\CouchbaseBucketCache instead.
+ * https://developer.couchbase.com/documentation/server/current/sdk/php/compatibility-versions-features.html
  */
 class CouchbaseCache extends CacheProvider
 {

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
@@ -17,12 +17,8 @@ class CouchbaseBucketCacheTest extends CacheTest
 
     protected function setUp() : void
     {
-        try {
-            $cluster = new Cluster('couchbase://localhost?detailed_errcodes=1');
-            $this->bucket = $cluster->openBucket('default');
-        } catch(\Exception $ex) {
-            $this->markTestSkipped('Could not instantiate the Couchbase cache because of: ' . $ex);
-        }
+        $cluster = new Cluster('couchbase://localhost?detailed_errcodes=1');
+        $this->bucket = $cluster->openBucket('default');
     }
 
     protected function _getCacheDriver() : CacheProvider

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Couchbase\Bucket;
+use Couchbase\Cluster;
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\CouchbaseBucketCache;
+
+/**
+ * @requires extension couchbase >=2.3
+ */
+class CouchbaseBucketCacheTest extends CacheTest
+{
+    /** @var Bucket */
+    private $bucket;
+
+    protected function setUp() : void
+    {
+        try {
+            $cluster = new Cluster('couchbase://localhost?detailed_errcodes=1');
+            $this->bucket = $cluster->openBucket('default');
+        } catch(\Exception $ex) {
+            $this->markTestSkipped('Could not instantiate the Couchbase cache because of: ' . $ex);
+        }
+    }
+
+    protected function _getCacheDriver() : CacheProvider
+    {
+        return new CouchbaseBucketCache($this->bucket);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
@@ -17,7 +17,7 @@ class CouchbaseBucketCacheTest extends CacheTest
 
     protected function setUp() : void
     {
-        $cluster = new Cluster('couchbase://localhost?detailed_errcodes=1');
+        $cluster      = new Cluster('couchbase://localhost?detailed_errcodes=1');
         $this->bucket = $cluster->openBucket('default');
     }
 

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -7,7 +7,8 @@ use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\CouchbaseCache;
 
 /**
- * @requires extension couchbase
+ * @requires extension couchbase >=1.0
+ * @requires extension couchbase <2.0
  */
 class CouchbaseCacheTest extends CacheTest
 {

--- a/tests/travis/Couchbase.sh
+++ b/tests/travis/Couchbase.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# @src https://github.com/matthiasmullie/scrapbook/blob/1.4.3/tests/.travis/Couchbase.sh
+
+docker pull webpt/couchbase-server:4.5.0
+docker run -d --name couchbase-server -p 8091:8091 -p 11210:11210 webpt/couchbase-server:4.5.0
+
+pecl uninstall couchbase
+
+sudo wget -O/etc/apt/sources.list.d/couchbase.list http://packages.couchbase.com/ubuntu/couchbase-ubuntu1204.list
+sudo wget -O- http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y libcouchbase2-libevent libcouchbase-dev
+pecl install pcs-1.3.1 couchbase --alldeps

--- a/tests/travis/php.ini
+++ b/tests/travis/php.ini
@@ -2,6 +2,7 @@ extension="apcu.so"
 extension="mongodb.so"
 extension="memcached.so"
 extension="redis.so"
+extension="couchbase.so"
 
 apc.enabled=1
 apc.enable_cli=1


### PR DESCRIPTION
fixes #216 

hi Team,

this request adds CouchbaseBucketCache which requires `ext-couchbase:^2.3.0`.

i've updated the Travis CI build to install the Couchbase extension, and am using a Couchbase Server Docker image forked by WebPT (my employer) which auto-creates the default bucket with flush enabled.

ext-couchbase version is checked in the CouchbaseBucketCache constructor, by ensuring that the `manager` method is callable.

`ext-couchbase:^2.0,<2.3.0` does not yet have `$bucket->manager()` which is required to flush the cache pool and to pull cluster stats. we might be able to support older versions of Couchbase 2.x, but i think we might lose some functionality that is required by this library's API. 

Couchbase throws an exception on delete if a key is not found. That is handled gracefully in this new provider.

Couchbase Manager's flush operation returns void, so you can't tell if it was successful, e.g. it will fail silently if flush is not enabled for the bucket on the server. i set a marker key into cache so that the marker can be queried for success of the flush operation.

i updated the old provider to indicate it is deprecated, with a reference to the new provider and a link to the deprecation documentation from Couchbase.

i added a new test case for this new provider, and tightened the phpunit test case requirement to control which test case is executed based on which specific version of the extension is installed.