### PR TITLE
Improve SQLite3 adapter

### DIFF
--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -70,15 +70,20 @@ class SQLite3Cache extends CacheProvider
         $this->sqlite = $sqlite;
         $this->table  = (string) $table;
 
-        list($id, $data, $exp) = $this->getFields();
+        $this->ensureTableExists();
+    }
 
-        return $this->sqlite->exec(sprintf(
-            'CREATE TABLE IF NOT EXISTS %s(%s TEXT PRIMARY KEY NOT NULL, %s BLOB, %s INTEGER)',
-            $table,
-            $id,
-            $data,
-            $exp
-        ));
+    private function ensureTableExists() : void
+    {
+        $this->sqlite->exec(
+            sprintf(
+                'CREATE TABLE IF NOT EXISTS %s(%s TEXT PRIMARY KEY NOT NULL, %s BLOB, %s INTEGER)',
+                $this->table,
+                static::ID_FIELD,
+                static::DATA_FIELD,
+                static::EXPIRATION_FIELD
+            )
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/SQLite3CacheTest.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Cache\SQLite3Cache;
 use SQLite3;
 
 /**
- * @requires extension sqlite3
+ * @requires extension sqlite3 >= 3
  */
 class SQLite3CacheTest extends CacheTest
 {


### PR DESCRIPTION
Tests were simply not being executed because PHPUnit was considering `sqlite` as extension name (instead of `sqlite3`) and we also had a weird `return` in the constructor.