### PR TITLE
Cache namespace version in own cache

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -216,9 +216,14 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
         if (null !== $this->namespaceVersion) {
             return $this->namespaceVersion;
         }
+        
+        $namespaceCacheKey = $this->getNamespaceCacheKey();
+        if($this->doContains($namespaceCacheKey)){
+            return $this->namespaceVersion = (int) $this->doFetch($namespaceCacheKey);
+        }
 
-        $namespaceCacheKey      = $this->getNamespaceCacheKey();
-        $this->namespaceVersion = (int) $this->doFetch($namespaceCacheKey) ?: 1;
+        $this->namespaceVersion = 1;
+        $this->doSave($namespaceCacheKey, $this->namespaceVersion);
 
         return $this->namespaceVersion;
     }

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -144,7 +144,7 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
         self::assertTrue($cache->deleteAll());
     }
 
-    public function testFetchWillNotResultInMissingCacheKeyAfterFirstTry(): void
+    public function testDoContainsOnlyCalledOnceForNamespaceCacheKey(): void
     {
         /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
         $cache = $this->getMockForAbstractClass(CacheProvider::class);

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -149,15 +149,13 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
         /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
         $cache = $this->getMockForAbstractClass(CacheProvider::class);
 
-        $cache->expects($this->once())
-              ->method('doContains')
-              ->with('DoctrineNamespaceCacheKey[]')
-              ->willReturn(false);
-
         $cache->expects($this->exactly(2))
               ->method('doFetch')
-              ->with('[missing_key][1]')
-              ->willReturn(false);
+              ->with('[missing_key][1]');
+
+        $cache->expects($this->once())
+              ->method('doContains')
+              ->with('DoctrineNamespaceCacheKey[]');
 
         $cache->fetch('missing_key');
         $cache->fetch('missing_key');

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -151,12 +151,13 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
 
         $cache->expects($this->once())
               ->method('doContains')
+              ->with('DoctrineNamespaceCacheKey[]')
               ->willReturn(false);
 
         $cache->expects($this->exactly(2))
               ->method('doFetch')
               ->with('[missing_key][1]')
-              ->willReturn(null);
+              ->willReturn(false);
 
         $cache->fetch('missing_key');
         $cache->fetch('missing_key');

--- a/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheProviderTest.php
@@ -143,4 +143,22 @@ class CacheProviderTest extends \Doctrine\Tests\DoctrineTestCase
 
         self::assertTrue($cache->deleteAll());
     }
+
+    public function testFetchWillNotResultInMissingCacheKeyAfterFirstTry(): void
+    {
+        /* @var $cache \Doctrine\Common\Cache\CacheProvider|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->getMockForAbstractClass(CacheProvider::class);
+
+        $cache->expects($this->once())
+              ->method('doContains')
+              ->willReturn(false);
+
+        $cache->expects($this->exactly(2))
+              ->method('doFetch')
+              ->with('[missing_key][1]')
+              ->willReturn(null);
+
+        $cache->fetch('missing_key');
+        $cache->fetch('missing_key');
+    }
 }


### PR DESCRIPTION
Actually every request generates one missing key (current namespaceCacheKey) as long as no "deleteAll" is called.