### PR TITLE
BC in abstract class CacheProvider from 1.6 to 1.7

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -189,7 +189,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      *
      * @return string The namespaced id.
      */
-    private function getNamespacedId(string $id) : string
+    private function getNamespacedId(?string $id) : string
     {
         $namespaceVersion = $this->getNamespaceVersion();
 


### PR DESCRIPTION
Hey @Ocramius 

i think with that lcobucci@e5b25d6fd461808fd2c6c8dda41e6d82a2b80202 commit of cause there was introduced a BC.
From version 1.6 to 1.7 the methode signature of the
```php   
abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, MultiGetCache, MultiPutCache
{
[...]
    private function getNamespacedId(string $id) : string
[...]
}
```
changed from `($id)` to `(string $id)`. Among others the method is called in the `public function fetch($id)` which hasn't any type hint in 1.7. In my case I come with a null value to the fetch method and now it results in a "Uncaught TypeError".

I think the signature should change to `private function getNamespacedId(?string $id) : string` or if it should be possible to come to the fetch method with a null value it should changed back to the original from 1.6. or `public function fetch(?string $id)`
If you would introduce a BC the fetch method should also be changed to `public function fetch(string $id)`

i've created the pull request but i'm not quite sure if other cases are also should be covered and if there is more to do you can give me some hints or rework it by yourself (maybe the faster way). For my purposes it seems to work with that. 😁

thx,
Eric