### PR TITLE
Add php-redis v4 support

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -6,6 +6,7 @@ use Redis;
 use function array_combine;
 use function defined;
 use function extension_loaded;
+use function is_bool;
 
 /**
  * Redis cache provider.
@@ -96,7 +97,13 @@ class RedisCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return $this->redis->exists($id);
+        $exists = $this->redis->exists($id);
+
+        if (is_bool($exists)) {
+            return $exists;
+        }
+
+        return $exists > 0;
     }
 
     /**


### PR DESCRIPTION
As desribed [here](https://github.com/phpredis/phpredis#exists),

Since php-redis v4 states that:
> This function took a single argument and returned TRUE or FALSE in phpredis versions < 4.0.0.

 We have to cast `doContains` functions with `bool` to return TRUE or FALSE.