### PR TITLE
Drop Coveralls config

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: travis-ci
-src_dir: lib
-coverage_clover: build/logs/clover.xml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 /tests export-ignore
-.coveralls.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore


### PR DESCRIPTION
Coveralls seems to have been dropped ages ago: https://coveralls.io/github/doctrine/cache
Scrutinizer is used for coverage now.