### PR TITLE
Exclude legacy untestable drivers from coverage & mark them deprecated

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -9,6 +9,8 @@ use function time;
  * Memcache cache provider.
  *
  * @link   www.doctrine-project.org
+ *
+ * @deprecated
  */
 class MemcacheCache extends CacheProvider
 {

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -15,6 +15,8 @@ use function unserialize;
  * Riak cache provider.
  *
  * @link   www.doctrine-project.org
+ *
+ * @deprecated
  */
 class RiakCache extends CacheProvider
 {

--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -17,6 +17,8 @@ use function xcache_unset;
  * Xcache cache driver.
  *
  * @link   www.doctrine-project.org
+ *
+ * @deprecated
  */
 class XcacheCache extends CacheProvider
 {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,13 @@
     <filter>
         <whitelist>
             <directory>./lib/Doctrine/</directory>
+            <exclude>
+                <file>lib/Doctrine/Common/Cache/ApcCache.php</file>
+                <file>lib/Doctrine/Common/Cache/CouchbaseCache.php</file>
+                <file>lib/Doctrine/Common/Cache/MemcacheCache.php</file>
+                <file>lib/Doctrine/Common/Cache/RiakCache.php</file>
+                <file>lib/Doctrine/Common/Cache/XcacheCache.php</file>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
All of these should be dropped eventually, none works with PHP 7.1+.