### PR TITLE
CI: Lock Couchbase extension to 2.4.6 to avoid dependency mismatch

### DIFF
--- a/tests/travis/Couchbase.sh
+++ b/tests/travis/Couchbase.sh
@@ -11,4 +11,4 @@ sudo wget -O/etc/apt/sources.list.d/couchbase.list http://packages.couchbase.com
 sudo wget -O- http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y libcouchbase2-libevent libcouchbase-dev
-pecl install pcs-1.3.1 couchbase --alldeps
+pecl install pcs-1.3.1 couchbase-2.4.6 --alldeps


### PR DESCRIPTION
https://github.com/couchbase/php-couchbase/commit/fb603f4b6a0ce3a34513d0233085a3b6d8e8b4f0
https://travis-ci.org/doctrine/cache/jobs/394094974#L1133

Couchbase 2.4.7 extension requires too new libcouchbase:
```
checking for libcouchbase in default path... found in /usr
checking for libcouchbase version >= 2.9.0... 0x020807
configure: error: libcouchbase greater or equal to 2.9.0 required
```