### PR TITLE
Updates that make the CouchbaseBucketCache provider nicer to use:

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseBucketCacheTest.php
@@ -17,12 +17,16 @@ class CouchbaseBucketCacheTest extends CacheTest
 
     protected function setUp() : void
     {
-        $cluster      = new Cluster('couchbase://localhost?detailed_errcodes=1');
+        $cluster = new Cluster('couchbase://localhost?detailed_errcodes=1');
+        $cluster->authenticateAs('Administrator', 'password');
+
         $this->bucket = $cluster->openBucket('default');
     }
 
     protected function _getCacheDriver() : CacheProvider
     {
-        return new CouchbaseBucketCache($this->bucket);
+        $driver = new CouchbaseBucketCache();
+        $driver->setBucket($this->bucket);
+        return $driver;
     }
 }

--- a/tests/travis/Couchbase.sh
+++ b/tests/travis/Couchbase.sh
@@ -2,13 +2,13 @@
 
 # @src https://github.com/matthiasmullie/scrapbook/blob/1.4.3/tests/.travis/Couchbase.sh
 
-docker pull webpt/couchbase-server:4.5.0
-docker run -d --name couchbase-server -p 8091:8091 -p 11210:11210 webpt/couchbase-server:4.5.0
+docker pull webpt/couchbase-server:5.0.1
+docker run -d --name couchbase-server -p 8091:8091 -p 11210:11210 webpt/couchbase-server:5.0.1
 
 pecl uninstall couchbase
 
-sudo wget -O/etc/apt/sources.list.d/couchbase.list http://packages.couchbase.com/ubuntu/couchbase-ubuntu1204.list
+sudo wget -O/etc/apt/sources.list.d/couchbase.list http://packages.couchbase.com/ubuntu/couchbase-ubuntu1404.list
 sudo wget -O- http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y libcouchbase2-libevent libcouchbase-dev
-pecl install pcs-1.3.1 couchbase --alldeps
+pecl install pcs-1.3.3 couchbase --alldeps


### PR DESCRIPTION
- Removing "final" class declaration
- Constants are now public
- No longer requiring bucket on construct, preferring getters
  and setters
  - This is more in keeping with other cache providers.
- normalizeKey and normalizeExpiry are now "protected", rather than
  private
- Adding small description to normalizeKey method
- Updating test to use new setter.
- Updating test shell script to use couchbase 5.0.1

I assume since this provider is not in a release yet it is still open
to community changes.