### PR TITLE
Reduce the number of namespace version lookups in the *Multiple methods

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -217,7 +217,7 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      *
      * @param string[] $ids The ids that will be namespaced
      *
-     * @return string[][] A map where the original id is the key and the namespaced id is the value
+     * @return string[] A map where the original id is the key and the namespaced id is the value
      */
     private function prepareNamespacedIdsMap(array $ids) : array
     {

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -95,6 +95,8 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
             $namespacedKeysAndValues[$namespacedKeys[$key]] = $value;
         }
 
+        unset($namespacedKeys);
+
         return $this->doSaveMultiple($namespacedKeysAndValues, $lifetime);
     }
 

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -182,11 +182,6 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
     /**
      * Return the passed id prefixed with the namespace value and suffixed
      * with the passed namespace version number
-     *
-     * @param string $id               The id to namespace.
-     * @param int    $namespaceVersion The namespace version number.
-     *
-     * @return string The namespaced id.
      */
     private function getNamespacedIdForVersion(string $id, int $namespaceVersion) : string
     {
@@ -220,9 +215,9 @@ abstract class CacheProvider implements Cache, FlushableCache, ClearableCache, M
      * Return a map containing the passed ids as keys and
      * their namespaced versions as keys
      *
-     * @param array $ids The ids that will be namespaced
+     * @param string[] $ids The ids that will be namespaced
      *
-     * @return array A map where the original id is the key and the namespaced id is the value
+     * @return string[][] A map where the original id is the key and the namespaced id is the value
      */
     private function prepareNamespacedIdsMap(array $ids) : array
     {


### PR DESCRIPTION
Currently the namespace version is pulled from the cache storage once for every id sent to the `*Multiple()` methods in the `CacheProvider`. This request aim to reduce the amount of these lookups by introducing a new method `prepareNamespacedIdsMap()` which pulls the version number only once for the whole batch of ids.