### PR TITLE
Alias Riak\Object as RiakObject to prevent errors in PHP 7.2

### DIFF
--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -180,9 +180,9 @@ class RiakCache extends CacheProvider
     }
 
     /**
-     * Check if a given Riak Object have expired.
+     * Check if a given RiakObject has expired.
      */
-    private function isExpired(object $object) : bool
+    private function isExpired(RiakObject $object) : bool
     {
         $metadataMap = $object->getMetadataMap();
 
@@ -208,7 +208,7 @@ class RiakCache extends CacheProvider
      * @param string $vClock
      * @param array  $objectList
      *
-     * @return Object
+     * @return RiakObject
      */
     protected function resolveConflict($id, $vClock, array $objectList)
     {

--- a/lib/Doctrine/Common/Cache/RiakCache.php
+++ b/lib/Doctrine/Common/Cache/RiakCache.php
@@ -5,7 +5,7 @@ namespace Doctrine\Common\Cache;
 use Riak\Bucket;
 use Riak\Exception;
 use Riak\Input;
-use Riak\Object;
+use Riak\Object as RiakObject;
 use function count;
 use function serialize;
 use function time;
@@ -111,7 +111,7 @@ class RiakCache extends CacheProvider
     protected function doSave($id, $data, $lifeTime = 0)
     {
         try {
-            $object = new Object($id);
+            $object = new RiakObject($id);
 
             $object->setContent(serialize($data));
 
@@ -218,7 +218,7 @@ class RiakCache extends CacheProvider
         $putInput = new Input\PutInput();
         $putInput->setVClock($vClock);
 
-        $mergedObject = new Object($id);
+        $mergedObject = new RiakObject($id);
         $mergedObject->setContent($winner->getContent());
 
         $this->bucket->put($mergedObject, $putInput);


### PR DESCRIPTION
As of PHP 7.2 `object` is a reserved word. Therefore, this line: https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/RiakCache.php#L8 triggers a PHP error in 7.2. This PR attempts to solve this issue by aliasing the import.

Issue: https://github.com/doctrine/cache/issues/292