### PR TITLE
CI: Test against PHP 7.4snapshot instead of nightly (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 php:
     - 7.1
     - 7.2
-    - nightly
+    - 7.4snapshot
 
 services:
     - riak
@@ -34,7 +34,7 @@ script: ./vendor/bin/phpunit --exclude-group performance
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: 7.4snapshot
 
   include:
     - stage: Coding standard


### PR DESCRIPTION
Couchbase extension build is currently failing, probably not much we can do on our end ATM, maybe disable it.