### PR TITLE
Move to doctrine/coding-standard 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "mongodb/mongodb": "^1.1",
         "phpunit/phpunit": "^7.0",
         "predis/predis":   "~1.0",
-        "doctrine/coding-standard": "^5.0"
+        "doctrine/coding-standard": "^6.0"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "401d5d5338e130168b78e6e408a3b181",
+    "content-hash": "743f7be1cafff709ad2e18acea708bd7",
     "packages": [],
     "packages-dev": [
         {
@@ -74,29 +74,27 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "squizlabs/php_codesniffer": "^2|^3"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -114,13 +112,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -138,32 +136,32 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2018-10-26T13:21:45+00:00"
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "bb8de042a25c4fb59a2c55c350dc55cc00227a8c"
+                "reference": "d33f69eb98b25aa51ffe3a909f0ec77000af4701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/bb8de042a25c4fb59a2c55c350dc55cc00227a8c",
-                "reference": "bb8de042a25c4fb59a2c55c350dc55cc00227a8c",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/d33f69eb98b25aa51ffe3a909f0ec77000af4701",
+                "reference": "d33f69eb98b25aa51ffe3a909f0ec77000af4701",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": "^7.1",
-                "slevomat/coding-standard": "^4.8.0",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "slevomat/coding-standard": "^5.0",
+                "squizlabs/php_codesniffer": "^3.4.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -199,7 +197,7 @@
                 "standard",
                 "style"
             ],
-            "time": "2018-09-24T19:08:56+00:00"
+            "time": "2019-03-15T12:45:47+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -684,6 +682,52 @@
                 "stub"
             ],
             "time": "2018-04-18T13:57:24+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/2cc49f47c69b023eaf05b48e6529389893b13d74",
+                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^2.0.0",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan": "^0.10",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^3.3.0",
+                "symfony/process": "^3.4 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "time": "2019-01-14T12:26:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1633,29 +1677,30 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "4.8.2",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "5e878708a16a75ed11a7d9aa02f50c257065d4fe"
+                "reference": "223f02b6193fe47b7b483bfa5bf75693535482dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/5e878708a16a75ed11a7d9aa02f50c257065d4fe",
-                "reference": "5e878708a16a75ed11a7d9aa02f50c257065d4fe",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/223f02b6193fe47b7b483bfa5bf75693535482dd",
+                "reference": "223f02b6193fe47b7b483bfa5bf75693535482dd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
-                "squizlabs/php_codesniffer": "^3.3.0"
+                "phpstan/phpdoc-parser": "^0.3.1",
+                "squizlabs/php_codesniffer": "^3.4.0"
             },
             "require-dev": {
                 "jakub-onderka/php-parallel-lint": "1.0.0",
                 "phing/phing": "2.16.1",
-                "phpstan/phpstan": "0.9.2",
-                "phpstan/phpstan-phpunit": "0.9.4",
-                "phpstan/phpstan-strict-rules": "0.9",
-                "phpunit/phpunit": "7.3.5"
+                "phpstan/phpstan": "0.11.1",
+                "phpstan/phpstan-phpunit": "0.11",
+                "phpstan/phpstan-strict-rules": "0.11",
+                "phpunit/phpunit": "8.0.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1668,20 +1713,20 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2018-09-25T06:49:15+00:00"
+            "time": "2019-03-12T20:26:36+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
                 "shasum": ""
             },
             "require": {
@@ -1719,7 +1764,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2018-12-19T23:57:18+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -63,6 +63,7 @@ class CouchbaseCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
         return $this->couchbase->set($id, $data, (int) $lifeTime);
     }
 
@@ -92,6 +93,7 @@ class CouchbaseCache extends CacheProvider
         $server  = explode(':', $servers[0]);
         $key     = $server[0] . ':11210';
         $stats   = $stats[$key];
+
         return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],

--- a/lib/Doctrine/Common/Cache/ExtMongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/ExtMongoDBCache.php
@@ -62,6 +62,7 @@ class ExtMongoDBCache extends CacheProvider
         if ($this->isExpired($document)) {
             $this->createExpirationIndex();
             $this->doDelete($id);
+
             return false;
         }
 
@@ -82,6 +83,7 @@ class ExtMongoDBCache extends CacheProvider
         if ($this->isExpired($document)) {
             $this->createExpirationIndex();
             $this->doDelete($id);
+
             return false;
         }
 

--- a/lib/Doctrine/Common/Cache/LegacyMongoDBCache.php
+++ b/lib/Doctrine/Common/Cache/LegacyMongoDBCache.php
@@ -55,6 +55,7 @@ class LegacyMongoDBCache extends CacheProvider
         if ($this->isExpired($document)) {
             $this->createExpirationIndex();
             $this->doDelete($id);
+
             return false;
         }
 
@@ -75,6 +76,7 @@ class LegacyMongoDBCache extends CacheProvider
         if ($this->isExpired($document)) {
             $this->createExpirationIndex();
             $this->doDelete($id);
+
             return false;
         }
 
@@ -160,7 +162,6 @@ class LegacyMongoDBCache extends CacheProvider
             $document[MongoDBCache::EXPIRATION_FIELD] instanceof MongoDate &&
             $document[MongoDBCache::EXPIRATION_FIELD]->sec < time();
     }
-
 
     private function createExpirationIndex() : void
     {

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -65,6 +65,7 @@ class MemcacheCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
         return $this->memcache->set($id, $data, 0, (int) $lifeTime);
     }
 
@@ -91,6 +92,7 @@ class MemcacheCache extends CacheProvider
     protected function doGetStats()
     {
         $stats = $this->memcache->getStats();
+
         return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -81,6 +81,7 @@ class MemcachedCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
         return $this->memcached->set($id, $data, (int) $lifeTime);
     }
 
@@ -119,6 +120,7 @@ class MemcachedCache extends CacheProvider
         $servers = $this->memcached->getServerList();
         $key     = $servers[0]['host'] . ':' . $servers[0]['port'];
         $stats   = $stats[$key];
+
         return [
             Cache::STATS_HITS   => $stats['get_hits'],
             Cache::STATS_MISSES => $stats['get_misses'],

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -148,6 +148,7 @@ class RedisCache extends CacheProvider
     protected function doGetStats()
     {
         $info = $this->redis->info();
+
         return [
             Cache::STATS_HITS   => $info['keyspace_hits'],
             Cache::STATS_MISSES => $info['keyspace_misses'],

--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -92,6 +92,7 @@ class XcacheCache extends CacheProvider
         $this->checkAuthorization();
 
         $info = xcache_info(XC_TYPE_VAR, 0);
+
         return [
             Cache::STATS_HITS   => $info['hits'],
             Cache::STATS_MISSES => $info['misses'],

--- a/lib/Doctrine/Common/Cache/ZendDataCache.php
+++ b/lib/Doctrine/Common/Cache/ZendDataCache.php
@@ -55,6 +55,7 @@ class ZendDataCache extends CacheProvider
         if (empty($namespace)) {
             return zend_shm_cache_clear();
         }
+
         return zend_shm_cache_clear($namespace);
     }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,6 +20,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration"/>
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+        <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,8 +18,8 @@
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
-        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration"/>
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -28,6 +28,7 @@ class CouchbaseCacheTest extends CacheTest
     {
         $driver = new CouchbaseCache();
         $driver->setCouchbase($this->couchbase);
+
         return $driver;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/FileCacheTest.php
@@ -162,7 +162,7 @@ class FileCacheTest extends DoctrineTestCase
         $basePath = realpath($basePath);
 
         // Test whether the desired path length is odd or even.
-        $desiredPathLengthIsOdd = ($pathLength % 2) == 1;
+        $desiredPathLengthIsOdd = $pathLength % 2 == 1;
 
         // If the cache key is not too long, the filecache codepath will add
         // a slash and bin2hex($key). The length of the added portion will be an odd number.
@@ -171,7 +171,7 @@ class FileCacheTest extends DoctrineTestCase
         //         even = odd            + odd
         $basePathLengthShouldBeOdd = ! $desiredPathLengthIsOdd;
 
-        $basePathLengthIsOdd = (strlen($basePath) % 2) == 1;
+        $basePathLengthIsOdd = strlen($basePath) % 2 == 1;
 
         // If the base path needs to be odd or even where it is not, we add an odd number of
         // characters as a pad. In this case, we're adding '\aa' (or '/aa' depending on platform)

--- a/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcacheCacheTest.php
@@ -59,6 +59,7 @@ class MemcacheCacheTest extends CacheTest
     {
         $driver = new MemcacheCache();
         $driver->setMemcache($this->memcache);
+
         return $driver;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/MemcachedCacheTest.php
@@ -89,6 +89,7 @@ class MemcachedCacheTest extends CacheTest
     {
         $driver = new MemcachedCache();
         $driver->setMemcached($this->memcached);
+
         return $driver;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PhpFileCacheTest.php
@@ -110,6 +110,7 @@ class SetStateClass extends NotSetStateClass
     public static function __set_state($data)
     {
         self::$values = $data;
+
         return new self($data['value']);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/RedisCacheTest.php
@@ -60,6 +60,7 @@ class RedisCacheTest extends CacheTest
     {
         $driver = new RedisCache();
         $driver->setRedis($this->_redis);
+
         return $driver;
     }
 }


### PR DESCRIPTION
Bumped the composer dependencies and fixed sniffs

In order to keep current behavior with `static::$constant` vs `self::$constant` I've added the sniff `SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants` to the exclude list.
