### PR TITLE
Changed RedisCache to use pipeline in operations with multiple keys

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -83,8 +83,6 @@ class RedisCache extends CacheProvider
     protected function doSaveMultiple(array $keysAndValues, $lifetime = 0)
     {
         if ($lifetime) {
-            $success = true;
-
             // Keys have lifetime, use SETEX for each of them
             $multi = $this->redis->multi(Redis::PIPELINE);
             foreach ($keysAndValues as $key => $value) {
@@ -92,7 +90,7 @@ class RedisCache extends CacheProvider
             }
             $succeeded = array_filter($multi->exec());
 
-            return count($succedeed) < count($keysAndValues);
+            return count($succedeed) == count($keysAndValues);
         }
 
         // No lifetime, use MSET


### PR DESCRIPTION
Redis has a feature named _pipelining_ to group commands to execute. It reduces the number of requests (TCP or Unix socket) to Redis server by sending multiple commands per 1 request. More info on Redis site: https://redis.io/topics/pipelining

In this PR I've wrapped all the commands, that are sent to Redis in loops, into pipelines. This will have a positive effect on performance of methods that are working with multiple keys (_doFetchMultiple_ and _doSaveMultiple_).