### PR TITLE
Prevent invalid memcached key to be used

### DIFF
--- a/lib/Doctrine/Common/Cache/InvalidCacheId.php
+++ b/lib/Doctrine/Common/Cache/InvalidCacheId.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Common\Cache;
+
+use InvalidArgumentException;
+use function sprintf;
+
+final class InvalidCacheId extends InvalidArgumentException
+{
+    public static function exceedsMaxLength($id, int $maxLength) : self
+    {
+        return new self(sprintf('Cache id "%s" exceeds maximum length %d', $id, $maxLength));
+    }
+
+    public static function containsUnauthorizedCharacter($id, string $character) : self
+    {
+        return new self(sprintf('Cache id "%s" contains unauthorized character "%s"', $id, $character));
+    }
+
+    public static function containsControlCharacter($id) : self
+    {
+        return new self(sprintf('Cache id "%s" contains at least one control character', $id));
+    }
+}


### PR DESCRIPTION
Here's the initial conversation: https://github.com/doctrine/cache/issues/208

This PR only ensures that memcached adapter provide valuable information while dealing with invalid key format.

TODO:

- [x] Fix CS
- [x] Generalize key format check (write operation only should be enough => saveMultiple)