### PR TITLE
apcu_fetch() emits E_NOTICE on read failure (undocumented):

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcuCache.php
+++ b/lib/Doctrine/Common/Cache/ApcuCache.php
@@ -23,7 +23,7 @@ class ApcuCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        return apcu_fetch($id);
+        return @apcu_fetch($id);
     }
 
     /**


### PR DESCRIPTION
`Notice: apcu_fetch(): Error at offset 1938 of 7810 bytes`
In most modern code, this gets converted to an \ErrorException.
As this is a cache (and a miss is handled), discard the notice silently.