### PR TITLE
Merge release 1.8.1 into master

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -123,7 +123,7 @@ class RedisCache extends CacheProvider
      */
     protected function doDelete($id)
     {
-        return $this->redis->delete($id) >= 0;
+        return $this->redis->del($id) >= 0;
     }
 
     /**
@@ -131,7 +131,7 @@ class RedisCache extends CacheProvider
      */
     protected function doDeleteMultiple(array $keys)
     {
-        return $this->redis->delete($keys) >= 0;
+        return $this->redis->del($keys) >= 0;
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/Version.php
+++ b/lib/Doctrine/Common/Cache/Version.php
@@ -4,5 +4,5 @@ namespace Doctrine\Common\Cache;
 
 class Version
 {
-    public const VERSION = '1.8.0';
+    public const VERSION = '1.8.1';
 }


### PR DESCRIPTION
Release [1.8.1](https://github.com/doctrine/cache/milestone/20)



1.8.1
=====

- Total issues resolved: **1**
- Total pull requests resolved: **1**
- Total contributors: **2**

Bug,Duplicate
-------------

 - [313: RedisCache delete is deprecated](https://github.com/doctrine/cache/issues/313) thanks to @flaushi

Improvement
-----------

 - [312: &#91;Redis&#93; Fix deprecation: Use `del` instead of `delete`](https://github.com/doctrine/cache/pull/312) thanks to @ruudk


