### PR TITLE
Fix flaky MongoDB test

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/ExtMongoDBCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ExtMongoDBCacheTest.php
@@ -56,10 +56,10 @@ class ExtMongoDBCacheTest extends CacheTest
     public function testLifetime() : void
     {
         $cache = $this->_getCacheDriver();
-        $cache->save('expire', 'value', 1);
+        $cache->save('expire', 'value', 2);
         self::assertCount(1, $this->collection->listIndexes());
         self::assertTrue($cache->contains('expire'), 'Data should not be expired yet');
-        sleep(2);
+        sleep(3);
         self::assertFalse($cache->contains('expire'), 'Data should be expired');
         self::assertCount(2, $this->collection->listIndexes());
     }


### PR DESCRIPTION
Fixes #326.

This definitely fixes the test failure. The only reason I have for those test failures is that if we write the record at the timestamp `1` with a lifetime of `1`, it is scheduled to expire at timestamp `2`. However, if we're close to the end of timestamp `1` (e.g. `1.98`), the record will be expired by the time we check if it's still there. This is a very specific scenario since we're running with a TTL of `1`, which isn't a production use-case. Using a TTL of `2` (and subsequently sleeping 3 seconds instead of 2) fixes the issue where expiration comes sooner than expected.

Note: not fixing in 1.9 as this is just a build system issue and we're releasing 1.10 soon anyways.