### PR TITLE
PSR-6 implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
         "mongodb/mongodb": "^1.1",
         "phpunit/phpunit": "^7.0",
         "predis/predis":   "~1.0",
-        "doctrine/coding-standard": "^6.0"
+        "doctrine/coding-standard": "^6.0",
+        "psr/cache": "^1.0",
+        "cache/integration-tests": "dev-master",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "743f7be1cafff709ad2e18acea708bd7",
+    "content-hash": "561f1edc828c05f630a7ba6799e545de",
     "packages": [],
     "packages-dev": [
         {
@@ -71,6 +71,123 @@
                 "mongodb"
             ],
             "time": "2018-03-05T20:40:55+00:00"
+        },
+        {
+            "name": "cache/integration-tests",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/integration-tests.git",
+                "reference": "e023fbe54c9821dfefbe04db0074ee8682f7f577"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/e023fbe54c9821dfefbe04db0074ee8682f7f577",
+                "reference": "e023fbe54c9821dfefbe04db0074ee8682f7f577",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": "^5.4|^7",
+                "psr/cache": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "cache/cache": "^1.0",
+                "illuminate/cache": "^5.4|^5.5|^5.6",
+                "mockery/mockery": "^1.0",
+                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
+                "symfony/phpunit-bridge": "^4.4",
+                "tedivm/stash": "^0.14"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\IntegrationTests\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
+            "homepage": "https://github.com/php-cache/integration-tests",
+            "keywords": [
+                "cache",
+                "psr16",
+                "psr6",
+                "test"
+            ],
+            "time": "2019-08-05T15:47:01+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "time": "2017-03-13T09:14:27+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1113,6 +1230,52 @@
             "time": "2016-06-16T16:22:20+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "sebastian/code-unit-reverse-lookup",
             "version": "1.0.1",
             "source": {
@@ -1767,6 +1930,71 @@
             "time": "2018-12-19T23:57:18+00:00"
         },
         {
+            "name": "symfony/phpunit-bridge",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "3c288a1f1a46ddffc299fd46ddb643d50debde85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/3c288a1f1a46ddffc299fd46ddb643d50debde85",
+                "reference": "3c288a1f1a46ddffc299fd46ddb643d50debde85",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3"
+            },
+            "suggest": {
+                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2019-11-08T16:32:03+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -1859,7 +2087,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "cache/integration-tests": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\ClearableCache;
+use Doctrine\Common\Cache\MultiOperationCache;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class CacheAdapter implements CacheItemPoolInterface
+{
+    /** @var Cache|ClearableCache|MultiOperationCache */
+    private $cache;
+
+    /**
+     * @var CacheItemInterface[]
+     */
+    private $deferredItems = [];
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItem($key): CacheItemInterface
+    {
+        $this->assertValidKey($key);
+
+        if (isset($this->deferredItems[$key])) {
+            return new CacheItem($key, $this->deferredItems[$key]->get());
+        }
+
+        return new CacheItem($key, $this->cache->fetch($key));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        $this->assertValidKeys($keys);
+
+        $fetchedValues = $this->cache->fetchMultiple($keys);
+        $items = [];
+        foreach ($keys as $key) {
+            $items[$key] = new CacheItem($key, isset($this->deferredItems[$key]) ? $this->deferredItems[$key]->get() : (\array_key_exists($key, $fetchedValues) ? $fetchedValues[$key] : false));
+        }
+
+        return $items;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasItem($key): bool
+    {
+        $this->assertValidKey($key);
+
+        return isset($this->deferredItems[$key])
+            ? !$this->isExpired($this->deferredItems[$key])
+            : $this->cache->contains($key)
+        ;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): bool
+    {
+        $this->deferredItems = [];
+
+        return $this->cache->deleteAll();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItem($key): bool
+    {
+        $this->assertValidKey($key);
+        unset($this->deferredItems[$key]);
+
+        return $this->cache->delete($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItems(array $keys): bool
+    {
+        $this->assertValidKeys($keys);
+
+        foreach ($keys as $key) {
+            unset($this->deferredItems[$key]);
+        }
+
+        return $this->cache->deleteMultiple($keys);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(CacheItemInterface $item): bool
+    {
+        unset($this->deferredItems[$item->getKey()]);
+
+        if ($this->isExpired($item)) {
+            return $this->cache->delete($item->getKey());
+        }
+
+        return $this->cache->save($item->getKey(), $item->get(), !$item instanceof CacheItem || null === $item->getExpiration() ? 0 : $item->getExpiration()->getTimestamp() - time());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        if ($this->isExpired($item)) {
+            return $this->cache->delete($item->getKey());
+        }
+
+        $this->deferredItems[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commit(): bool
+    {
+        $success =  $this->cache->saveMultiple(array_map(
+            static function (CacheItemInterface $cacheItem) {
+                return $cacheItem->get();
+            },
+            $this->deferredItems
+        ));
+
+        if ($success) {
+            $this->deferredItems = [];
+        }
+
+        return $success;
+    }
+
+    public function __destruct()
+    {
+        $this->commit();
+    }
+
+    private function assertValidKey($key): void
+    {
+        if (!\is_string($key) || '' === $key || preg_match('#[\{\}\(\)/\\\\@:]#', $key)) {
+            throw new InvalidArgumentException('Invalid cache key.');
+        }
+    }
+
+    private function assertValidKeys(iterable $keys): void
+    {
+        foreach ($keys as $key) {
+            $this->assertValidKey($key);
+        }
+    }
+
+    private function isExpired(CacheItemInterface $item): bool
+    {
+        return $item instanceof CacheItem
+            && null !== $item->getExpiration()
+            && $item->getExpiration() < new \DateTimeImmutable()
+        ;
+    }
+}

--- a/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
@@ -62,7 +62,10 @@ final class CacheItem implements CacheItemInterface
     public function expiresAt($expiration): self
     {
         if (null !== $expiration && !$expiration instanceof \DateTimeInterface) {
-            throw new \TypeError(sprintf('Expected $expiration to be an instance of DateTimeInterface or null, got %s', \is_object($expiration) ? \get_class($expiration) : \gettype($expiration)));
+            throw new \TypeError(sprintf(
+                'Expected $expiration to be an instance of DateTimeInterface or null, got %s',
+                \is_object($expiration) ? \get_class($expiration) : \gettype($expiration)
+            ));
         }
 
         $this->expiration = $expiration;

--- a/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6;
+
+use Psr\Cache\CacheItemInterface;
+
+final class CacheItem implements CacheItemInterface
+{
+    /** @var string */
+    private $key;
+    /** @var mixed */
+    private $value;
+    /** @var bool */
+    private $hit;
+    /** @var \DateTimeInterface|null */
+    private $expiration;
+
+    public function __construct(string $key, $data)
+    {
+        $this->key = $key;
+        $this->value = false === $data ? null : $data;
+        $this->hit = false !== $data;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHit(): bool
+    {
+        return $this->hit;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAt($expiration): self
+    {
+        if (null !== $expiration && !$expiration instanceof \DateTimeInterface) {
+            throw new \TypeError(sprintf('Expected $expiration to be an instance of DateTimeInterface or null, got %s', \is_object($expiration) ? \get_class($expiration) : \gettype($expiration)));
+        }
+
+        $this->expiration = $expiration;
+
+        return $this;
+    }
+    /**
+     * @inheritDoc
+     */
+    public function expiresAfter($time): self
+    {
+        if (null === $time) {
+            $this->expiration = null;
+        } elseif (is_numeric($time)) {
+            $this->expiration = new \DateTimeImmutable(sprintf('now +%d seconds', $time));
+        } elseif ($time instanceof \DateInterval) {
+            $this->expiration = (new \DateTimeImmutable())->add($time);
+        } else {
+            throw new \TypeError(sprintf('Expected $time to be either an integer, an instance of DateInterval or null, got %s', \is_object($time) ? \get_class($time) : \gettype($time)));
+        }
+
+        return $this;
+    }
+
+    public function getExpiration(): ?\DateTimeInterface
+    {
+        return $this->expiration;
+    }
+}

--- a/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
@@ -84,7 +84,10 @@ final class CacheItem implements CacheItemInterface
         } elseif ($time instanceof \DateInterval) {
             $this->expiration = (new \DateTimeImmutable())->add($time);
         } else {
-            throw new \TypeError(sprintf('Expected $time to be either an integer, an instance of DateInterval or null, got %s', \is_object($time) ? \get_class($time) : \gettype($time)));
+            throw new \TypeError(sprintf(
+                'Expected $time to be either an integer, an instance of DateInterval or null, got %s',
+                \is_object($time) ? \get_class($time) : \gettype($time)
+            ));
         }
 
         return $this;

--- a/lib/Doctrine/Common/Cache/Psr6/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Cache/Psr6/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6;
+
+final class InvalidArgumentException extends \RuntimeException implements \Psr\Cache\InvalidArgumentException
+{
+}

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache\Psr6;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class CacheAdapterTest extends CachePoolTest
+{
+    private $arrayCache;
+
+    /**
+     * @inheritDoc
+     */
+    public function createCachePool(): CacheItemPoolInterface
+    {
+        if (!$this->arrayCache) {
+            $this->arrayCache = new ArrayCache();
+        }
+
+        return new CacheAdapter($this->arrayCache);
+    }
+}


### PR DESCRIPTION
The adapter added with this PR allows us to use Doctrine Cache as a PSR-6 implementation. This will allow us to decouple various Doctrine libraries from Doctrine cache.

#SymfonyHackday