### PR TITLE
Allow to indicate default TTL for downstream CacheProviders

### DIFF
--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -15,6 +15,9 @@ class ChainCache extends CacheProvider
     /** @var CacheProvider[] */
     private $cacheProviders = [];
 
+    /** @var int */
+    private $defaultLifeTimeForDownstreamCacheProviders;
+
     /**
      * @param CacheProvider[] $cacheProviders
      */
@@ -23,6 +26,11 @@ class ChainCache extends CacheProvider
         $this->cacheProviders = $cacheProviders instanceof Traversable
             ? iterator_to_array($cacheProviders, false)
             : array_values($cacheProviders);
+    }
+
+    public function setDefaultLifeTimeForDownstreamCacheProviders(int $defaultLifeTimeForDownstreamCacheProviders) : void
+    {
+        $this->defaultLifeTimeForDownstreamCacheProviders = $defaultLifeTimeForDownstreamCacheProviders;
     }
 
     /**
@@ -48,7 +56,7 @@ class ChainCache extends CacheProvider
 
                 // We populate all the previous cache layers (that are assumed to be faster)
                 for ($subKey = $key - 1; $subKey >= 0; $subKey--) {
-                    $this->cacheProviders[$subKey]->doSave($id, $value);
+                    $this->cacheProviders[$subKey]->doSave($id, $value, $this->defaultLifeTimeForDownstreamCacheProviders);
                 }
 
                 return $value;

--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -16,7 +16,7 @@ class ChainCache extends CacheProvider
     private $cacheProviders = [];
 
     /** @var int */
-    private $defaultLifeTimeForDownstreamCacheProviders;
+    private $defaultLifeTimeForDownstreamCacheProviders = 0;
 
     /**
      * @param CacheProvider[] $cacheProviders

--- a/lib/Doctrine/Common/Cache/ChainCache.php
+++ b/lib/Doctrine/Common/Cache/ChainCache.php
@@ -82,7 +82,7 @@ class ChainCache extends CacheProvider
             // We populate all the previous cache layers (that are assumed to be faster)
             if (count($fetchedValues) === $keysCount) {
                 foreach ($traversedProviders as $previousCacheProvider) {
-                    $previousCacheProvider->doSaveMultiple($fetchedValues);
+                    $previousCacheProvider->doSaveMultiple($fetchedValues, $this->defaultLifeTimeForDownstreamCacheProviders);
                 }
 
                 return $fetchedValues;

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -70,11 +70,11 @@ class ChainCacheTest extends CacheTest
 
     public function testFetchPropagatesToFastestCacheUsingDefaultLifeTimeForDownstreamCacheProviders() : void
     {
-        $defaultLifeTimeForDownstreamCacheProviders = 12345;
+        $defaultLifeTimeForDownstreamCacheProviders = 0;
 
         $cache1 = $this
             ->getMockBuilder(ArrayCache::class)
-            ->onlyMethods(['doSave'])
+            ->setMethods(['doSave'])
             ->getMock();
         $cache1
             ->expects($this->once())
@@ -84,7 +84,29 @@ class ChainCacheTest extends CacheTest
         $cache2->save('bar', 'value');
 
         $chainCache = new ChainCache([$cache1, $cache2]);
-        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($defaultLifeTimeForDownstreamCacheProviders);
+
+        $result = $chainCache->fetch('bar');
+
+        self::assertEquals('value', $result);
+    }
+
+    public function testFetchPropagatesToFastestCacheUsingIndicatedDefaultLifeTimeForDownstreamCacheProviders() : void
+    {
+        $pecificDefaultLifeTimeForDownstreamCacheProviders = 12345;
+
+        $cache1 = $this
+            ->getMockBuilder(ArrayCache::class)
+            ->setMethods(['doSave'])
+            ->getMock();
+        $cache1
+            ->expects($this->once())
+            ->method('doSave')
+            ->with('[bar][1]', 'value', $pecificDefaultLifeTimeForDownstreamCacheProviders);
+        $cache2 = new ArrayCache();
+        $cache2->save('bar', 'value');
+
+        $chainCache = new ChainCache([$cache1, $cache2]);
+        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($pecificDefaultLifeTimeForDownstreamCacheProviders);
 
         $result = $chainCache->fetch('bar');
 
@@ -110,23 +132,23 @@ class ChainCacheTest extends CacheTest
         self::assertTrue($cache1->contains('foo'));
     }
 
-    public function testFetchMultiplePropagatesToFastestCacheUsingDefaultLifeTimeForDownstreamCacheProviders() : void
+    public function testFetchMultiplePropagatesToFastestCacheUsingIndicatedDefaultLifeTimeForDownstreamCacheProviders() : void
     {
-        $defaultLifeTimeForDownstreamCacheProviders = 12345;
+        $pecificDefaultLifeTimeForDownstreamCacheProviders = 12345;
 
         $cache1 = $this
             ->getMockBuilder(ArrayCache::class)
-            ->onlyMethods(['doSaveMultiple'])
+            ->setMethods(['doSaveMultiple'])
             ->getMock();
         $cache1
             ->expects($this->once())
             ->method('doSaveMultiple')
-            ->with(['[bar][1]' => 'Bar', '[foo][1]' => 'Foo'], $defaultLifeTimeForDownstreamCacheProviders);
+            ->with(['[bar][1]' => 'Bar', '[foo][1]' => 'Foo'], $pecificDefaultLifeTimeForDownstreamCacheProviders);
         $cache2 = new ArrayCache();
         $cache2->saveMultiple(['bar' => 'Bar', 'foo' => 'Foo']);
 
         $chainCache = new ChainCache([$cache1, $cache2]);
-        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($defaultLifeTimeForDownstreamCacheProviders);
+        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($pecificDefaultLifeTimeForDownstreamCacheProviders);
 
         $result = $chainCache->fetchMultiple(['bar', 'foo']);
 

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -92,7 +92,7 @@ class ChainCacheTest extends CacheTest
 
     public function testFetchPropagatesToFastestCacheUsingIndicatedDefaultLifeTimeForDownstreamCacheProviders() : void
     {
-        $pecificDefaultLifeTimeForDownstreamCacheProviders = 12345;
+        $specificDefaultLifeTimeForDownstreamCacheProviders = 12345;
 
         $cache1 = $this
             ->getMockBuilder(ArrayCache::class)
@@ -101,12 +101,12 @@ class ChainCacheTest extends CacheTest
         $cache1
             ->expects($this->once())
             ->method('doSave')
-            ->with('[bar][1]', 'value', $pecificDefaultLifeTimeForDownstreamCacheProviders);
+            ->with('[bar][1]', 'value', $specificDefaultLifeTimeForDownstreamCacheProviders);
         $cache2 = new ArrayCache();
         $cache2->save('bar', 'value');
 
         $chainCache = new ChainCache([$cache1, $cache2]);
-        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($pecificDefaultLifeTimeForDownstreamCacheProviders);
+        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($specificDefaultLifeTimeForDownstreamCacheProviders);
 
         $result = $chainCache->fetch('bar');
 
@@ -134,7 +134,7 @@ class ChainCacheTest extends CacheTest
 
     public function testFetchMultiplePropagatesToFastestCacheUsingIndicatedDefaultLifeTimeForDownstreamCacheProviders() : void
     {
-        $pecificDefaultLifeTimeForDownstreamCacheProviders = 12345;
+        $specificDefaultLifeTimeForDownstreamCacheProviders = 12345;
 
         $cache1 = $this
             ->getMockBuilder(ArrayCache::class)
@@ -143,12 +143,12 @@ class ChainCacheTest extends CacheTest
         $cache1
             ->expects($this->once())
             ->method('doSaveMultiple')
-            ->with(['[bar][1]' => 'Bar', '[foo][1]' => 'Foo'], $pecificDefaultLifeTimeForDownstreamCacheProviders);
+            ->with(['[bar][1]' => 'Bar', '[foo][1]' => 'Foo'], $specificDefaultLifeTimeForDownstreamCacheProviders);
         $cache2 = new ArrayCache();
         $cache2->saveMultiple(['bar' => 'Bar', 'foo' => 'Foo']);
 
         $chainCache = new ChainCache([$cache1, $cache2]);
-        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($pecificDefaultLifeTimeForDownstreamCacheProviders);
+        $chainCache->setDefaultLifeTimeForDownstreamCacheProviders($specificDefaultLifeTimeForDownstreamCacheProviders);
 
         $result = $chainCache->fetchMultiple(['bar', 'foo']);
 
@@ -227,5 +227,4 @@ class ChainCacheTest extends CacheTest
     {
         return false;
     }
-
 }


### PR DESCRIPTION
Allows users to resolve bug described in https://github.com/doctrine/cache/issues/246 where downstream CacheProviders are populated with cache entries with infinite lifetime, causing "strange" behavior: never expiring cache entries.

Behaviour is unchanged by default. 

Suggestions on how to test this are welcome 🤓 