### PR TITLE
Add support for atomic fetch with save if not found

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcuCache.php
+++ b/lib/Doctrine/Common/Cache/ApcuCache.php
@@ -2,14 +2,17 @@
 
 namespace Doctrine\Common\Cache;
 
+use RuntimeException;
 use function apcu_cache_info;
 use function apcu_clear_cache;
 use function apcu_delete;
+use function apcu_entry;
 use function apcu_exists;
 use function apcu_fetch;
 use function apcu_sma_info;
 use function apcu_store;
 use function count;
+use function function_exists;
 
 /**
  * APCu cache provider.
@@ -67,6 +70,18 @@ class ApcuCache extends CacheProvider
     protected function doFlush()
     {
         return apcu_clear_cache();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetchAtomic(string $id, callable $generator, int $ttl)
+    {
+        if (! function_exists('apcu_entry')) {
+            throw new RuntimeException('Atomic fetch (apcu_entry) is not supported by this version of apcu');
+        }
+
+        return apcu_entry($id, $generator, $ttl);
     }
 
     /**

--- a/lib/Doctrine/Common/Cache/AtomicFetchCache.php
+++ b/lib/Doctrine/Common/Cache/AtomicFetchCache.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Common\Cache;
+
+interface AtomicFetchCache
+{
+    /**
+     * Atomically fetches an item from the cache, or stores and returns the data from the generator
+     *
+     * @return mixed
+     */
+    public function fetchAtomic(string $id, callable $generator, int $ttl = 0);
+}


### PR DESCRIPTION
APCu supports using `apcu_entry` to fetch an entry and save data using a generator if it's not found in the cache. These changes support that, as well as using (p)Redis pipelines with the atomic option to do the same.

I have implemented a fallback that is not atomic, but does the same for non-atomic providers.

In theory it would be possible to semi-replicate the atomic behaviour for providers that support transactions - while not strictly atomic, the implementation would be the similar with the fetch/save steps being grouped.