### PR TITLE
Merge release 1.10.1 into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,15 @@ install:
 script: ./vendor/bin/phpunit --exclude-group performance
 
 jobs:
+  allow_failures:
+    - php: nightly
+
   include:
+    -   stage: Test
+        php: nightly
+        before_install:
+            - composer config platform.php 7.4.99
+
     - stage: Coding standard
       install:
           - travis_retry composer install --no-interaction --prefer-dist --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
 
 services:
     - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: php
 
 cache:

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/doctrine/cache.svg?style=flat-square)](https://packagist.org/packages/doctrine/cache)
 [![Total Downloads](https://img.shields.io/packagist/dt/doctrine/cache.svg?style=flat-square)](https://packagist.org/packages/doctrine/cache)
 
-Cache component extracted from the Doctrine Common project. [Documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/caching.html)
+Cache component extracted from the Doctrine Common project. [Documentation](https://www.doctrine-project.org/projects/doctrine-cache/en/current/index.html)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~7.1"
+        "php": "~7.1 || ^8.0"
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "743f7be1cafff709ad2e18acea708bd7",
+    "content-hash": "7541182ab51ae64a4be35602ca0c3c59",
     "packages": [],
     "packages-dev": [
         {
@@ -1863,7 +1863,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.1"
+        "php": "~7.1 || ^8.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Release [1.10.1](https://github.com/doctrine/cache/milestone/24)



1.10.1
======

- Total issues resolved: **0**
- Total pull requests resolved: **1**
- Total contributors: **1**




 - [343: Allow PHP 8](https://github.com/doctrine/cache/pull/343) thanks to @greg0ire


