### PR TITLE
Update Composer, Travis Config and ChainCachetest for 8.0 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 install:
     - rm composer.lock
-    - travis_retry composer update --no-interaction --prefer-dist
+    - travis_retry composer update --no-interaction --prefer-dist --ignore-platform-reqs
 
 script: ./vendor/bin/phpunit --exclude-group performance
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
         "mongodb/mongodb": "^1.1",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5 || ^9.1.5",
         "predis/predis":   "~1.0",
         "doctrine/coding-standard": "^6.0"
     },

--- a/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/ChainCacheTest.php
@@ -19,7 +19,7 @@ class ChainCacheTest extends CacheTest
         $cache = $this->_getCacheDriver();
         $stats = $cache->getStats();
 
-        self::assertInternalType('array', $stats);
+        self::assertIsArray($stats);
     }
 
     public function testOnlyFetchFirstOne() : void


### PR DESCRIPTION
- Run travis update --ignore-platform-reqs to avoid mongodb problem
- Update Composer to allow PHPUnit 9
- Fix ChainCacheTest to not use deprecated PHPUnit API