### PR TITLE
SQLite3Cache: Statement can be false.

### DIFF
--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -2,12 +2,14 @@
 
 namespace Doctrine\Common\Cache;
 
+use RuntimeException;
 use SQLite3;
 use SQLite3Result;
 use const SQLITE3_ASSOC;
 use const SQLITE3_BLOB;
 use const SQLITE3_TEXT;
 use function array_search;
+use function error_get_last;
 use function implode;
 use function serialize;
 use function sprintf;
@@ -166,7 +168,7 @@ class SQLite3Cache extends CacheProvider
         ));
 
         if ($statement === false) {
-            throw new \RuntimeException('SQLite internal database structure is broken: ' . (error_get_last()['message'] ?? ''));
+            throw new RuntimeException('SQLite internal database structure is broken: ' . (error_get_last()['message'] ?? ''));
         }
 
         $statement->bindValue(':id', $id, SQLITE3_TEXT);

--- a/lib/Doctrine/Common/Cache/SQLite3Cache.php
+++ b/lib/Doctrine/Common/Cache/SQLite3Cache.php
@@ -165,6 +165,10 @@ class SQLite3Cache extends CacheProvider
             $idField
         ));
 
+        if ($statement === false) {
+            throw new \RuntimeException('SQLite internal database structure is broken: ' . (error_get_last()['message'] ?? ''));
+        }
+
         $statement->bindValue(':id', $id, SQLITE3_TEXT);
 
         $item = $statement->execute()->fetchArray(SQLITE3_ASSOC);


### PR DESCRIPTION
In the event of an error in the set rights during the life of the application, the structure or content of the cached file may be damaged.

Doctrine does not currently throw an exception, but the entire request will end in a fatal error that simply cannot be processed further.

I suggest throwing an exception in such a case.

This type of error has happened 1000 times in my production application in the last month.

Real example:

![Snímek obrazovky 2020-10-17 v 23 10 12](https://user-images.githubusercontent.com/4738758/96353616-0ea60200-10ce-11eb-932e-ec98cdb931d7.png)

Thanks.