### PR TITLE
Fixed fetchMultiple method for the Predis cache provider.

### DIFF
--- a/lib/Doctrine/Common/Cache/PredisCache.php
+++ b/lib/Doctrine/Common/Cache/PredisCache.php
@@ -7,6 +7,7 @@ use Predis\ClientInterface;
 use function array_combine;
 use function array_filter;
 use function array_map;
+use function array_values;
 use function call_user_func_array;
 use function serialize;
 use function unserialize;
@@ -42,7 +43,7 @@ class PredisCache extends CacheProvider
      */
     protected function doFetchMultiple(array $keys)
     {
-        $fetchedItems = call_user_func_array([$this->client, 'mget'], $keys);
+        $fetchedItems = call_user_func_array([$this->client, 'mget'], array_values($keys));
 
         return array_map('unserialize', array_filter(array_combine($keys, $fetchedItems)));
     }

--- a/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/PredisCacheTest.php
@@ -90,9 +90,4 @@ class PredisCacheTest extends CacheTest
 
         self::assertInstanceOf(PredisCache::class, new PredisCache($predisClient));
     }
-
-    public function testFetchMultiple(): void
-    {
-        $this->markTestSkipped('this is probably a bug that needs to be fixed');
-    }
 }


### PR DESCRIPTION
The `\Predis\Client::mget()` method doesn't accept an associative array. This leads to the warning at PHP 8. 

The method works without warnings on PHP < 8 with an associative array as the argument, but it always returns an indexed array. So it is safe to call it with `array_values($keys)` instead of `$keys` because it's mapped back to keys using array_combine in the next line. 

As a result, we can enable back `testFetchMultiple` for the PredisCacheTest, skipped by @greg0ire in https://github.com/doctrine/cache/commit/87fa0a8b0aa852e1bd9541018bf3eb95cb91181a  because it doesn't fail anymore.