### PR TITLE
Allow psr/cache 2 and disallow psr/cache 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,15 @@
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
         "predis/predis":   "~1.0",
         "doctrine/coding-standard": "^8.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "cache/integration-tests": "dev-master"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
     },
     "conflict": {
-        "doctrine/common": ">2.2,<2.4"
+        "doctrine/common": ">2.2,<2.4",
+        "psr/cache": ">=3"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache" }


### PR DESCRIPTION
Follow-up to #360 (@nicolas-grekas). The new PSR-6 adapter is compatible with version 2 of the interfaces, which requires PHP 8.0. This PR makes sure we run the tests with `psr/cache` 2 on the PHP 8 build.

Version 3 however requires us to use a `mixed` return type. We cannot do this without bumping the minimum requirement of this library to PHP 8 as well. The current code would cause a fatal error if `psr/cache` 3 was installed. Because of that, I've added a conflict rule.