### PR TITLE
Import DoctrineProvider class to remove dependencies on symfony/cache

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -11,6 +11,5 @@ There are two new classes to use in the `Doctrine\Common\Cache\Psr6` namespace:
   Doctrine cache implementations and switch to PSR-6.
 * The `DoctrineProvider` class allows using any PSR-6 cache as Doctrine cache.
   This implementation is designed for libraries that leak the cache and want to
-  switch to allowing PSR-6 implementations. This class is marked as internal and
-  should only be used during the transition phase of sunsetting doctrine/cache
-  support.
+  switch to allowing PSR-6 implementations. This class is design to be used
+  during the transition phase of sunsetting doctrine/cache support.

--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -4,3 +4,13 @@ doctrine/cache will no longer be maintained and all cache implementations have
 been marked as deprecated. These implementations will be removed in 2.0, which
 will only contain interfaces to provide a lightweight package for backward
 compatibility.
+
+There are two new classes to use in the `Doctrine\Common\Cache\Psr6` namespace:
+* The `CacheAdapter` class allows using any Doctrine Cache as PSR-6 cache. This
+  is useful to provide a forward compatibility layer in libraries that accept
+  Doctrine cache implementations and switch to PSR-6.
+* The `DoctrineProvider` class allows using any PSR-6 cache as Doctrine cache.
+  This implementation is designed for libraries that leak the cache and want to
+  switch to allowing PSR-6 implementations. This class is marked as internal and
+  should only be used during the transition phase of sunsetting doctrine/cache
+  support.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "predis/predis":   "~1.0",
         "doctrine/coding-standard": "^8.0",
         "psr/cache": "^1.0 || ^2.0",
-        "cache/integration-tests": "dev-master"
+        "cache/integration-tests": "dev-master",
+        "symfony/cache": "^4.4 || ^5.2"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -20,8 +20,6 @@ use function rawurlencode;
  * This class was copied from the Symfony Framework, see the original copyright
  * notice above. The code is distributed subject to the license terms in
  * https://github.com/symfony/symfony/blob/ff0cf61278982539c49e467db9ab13cbd342f76d/LICENSE
- *
- * @internal
  */
 final class DoctrineProvider extends CacheProvider
 {

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Common\Cache\Psr6;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Psr\Cache\CacheItemPoolInterface;
+
+use function rawurlencode;
+
+/**
+ * This class was copied from the Symfony Framework, see the original copyright
+ * notice above. The code is distributed subject to the license terms in
+ * https://github.com/symfony/symfony/blob/ff0cf61278982539c49e467db9ab13cbd342f76d/LICENSE
+ *
+ * @internal
+ */
+final class DoctrineProvider extends CacheProvider
+{
+    /** @var CacheItemPoolInterface */
+    private $pool;
+
+    public function __construct(CacheItemPoolInterface $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        $item = $this->pool->getItem(rawurlencode($id));
+
+        return $item->isHit() ? $item->get() : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    protected function doContains($id)
+    {
+        return $this->pool->hasItem(rawurlencode($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        $item = $this->pool->getItem(rawurlencode($id));
+
+        if (0 < $lifeTime) {
+            $item->expiresAfter($lifeTime);
+        }
+
+        return $this->pool->save($item->set($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    protected function doDelete($id)
+    {
+        return $this->pool->deleteItem(rawurlencode($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    protected function doFlush()
+    {
+        return $this->pool->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array|null
+     */
+    protected function doGetStats()
+    {
+        return null;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Tests\Common\Cache\Psr6;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class DoctrineProviderTest extends TestCase
+{
+    public function testProvider()
+    {
+        $pool  = new ArrayAdapter();
+        $cache = new DoctrineProvider($pool);
+
+        $this->assertInstanceOf(CacheProvider::class, $cache);
+
+        $key = '{}()/\@:';
+
+        $this->assertTrue($cache->delete($key));
+        $this->assertFalse($cache->contains($key));
+
+        $this->assertTrue($cache->save($key, 'bar'));
+        $this->assertTrue($cache->contains($key));
+        $this->assertSame('bar', $cache->fetch($key));
+
+        $this->assertTrue($cache->delete($key));
+        $this->assertFalse($cache->fetch($key));
+        $this->assertTrue($cache->save($key, 'bar'));
+
+        $cache->flushAll();
+        $this->assertFalse($cache->fetch($key));
+        $this->assertFalse($cache->contains($key));
+    }
+}


### PR DESCRIPTION
This PR adds the DoctrineProvider class from symfony/cache. The class is marked as `@internal` and is designed for use in various other Doctrine packages that leak their caches (e.g. persistence). Users of doctrine/cache should not use this class at all.

The symfony/cache dev dependency is there to allow testing against an actual PSR-6 class - alternatively I could wrap a doctrine `ArrayCache` in a `CacheAdapter` and test against that, but it somehow seems wrong.