### PR TITLE
Prevent wrapping chains of cache wrappers

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -30,7 +30,12 @@ final class CacheAdapter implements CacheItemPoolInterface
     /** @var CacheItem[] */
     private $deferredItems = [];
 
-    public function __construct(Cache $cache)
+    public static function wrap(Cache $cache): CacheItemPoolInterface
+    {
+        return new self($cache);
+    }
+
+    private function __construct(Cache $cache)
     {
         $this->cache = $cache;
     }

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -26,7 +26,12 @@ final class DoctrineProvider extends CacheProvider
     /** @var CacheItemPoolInterface */
     private $pool;
 
-    public function __construct(CacheItemPoolInterface $pool)
+    public static function wrap(CacheItemPoolInterface $pool): CacheProvider
+    {
+        return new self($pool);
+    }
+
+    private function __construct(CacheItemPoolInterface $pool)
     {
         $this->pool = $pool;
     }

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -13,6 +13,7 @@ namespace Doctrine\Common\Cache\Psr6;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
 
 use function rawurlencode;
 
@@ -28,12 +29,31 @@ final class DoctrineProvider extends CacheProvider
 
     public static function wrap(CacheItemPoolInterface $pool): CacheProvider
     {
+        if ($pool instanceof CacheAdapter) {
+            return $pool->getCache();
+        }
+
+        if ($pool instanceof SymfonyDoctrineAdapter) {
+            $getCache = function () {
+                // phpcs:ignore Squiz.Scope.StaticThisUsage.Found
+                return $this->provider;
+            };
+
+            return $getCache->bindTo($pool, SymfonyDoctrineAdapter::class)();
+        }
+
         return new self($pool);
     }
 
     private function __construct(CacheItemPoolInterface $pool)
     {
         $this->pool = $pool;
+    }
+
+    /** @internal */
+    public function getPool(): CacheItemPoolInterface
+    {
+        return $this->pool;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -18,6 +18,6 @@ final class CacheAdapterTest extends CachePoolTest
             $this->arrayCache = new ArrayCache();
         }
 
-        return new CacheAdapter($this->arrayCache);
+        return CacheAdapter::wrap($this->arrayCache);
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -5,7 +5,10 @@ namespace Doctrine\Tests\Common\Cache\Psr6;
 use Cache\IntegrationTests\CachePoolTest;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\DoctrineProvider as SymfonyDoctrineProvider;
 
 final class CacheAdapterTest extends CachePoolTest
 {
@@ -19,5 +22,21 @@ final class CacheAdapterTest extends CachePoolTest
         }
 
         return CacheAdapter::wrap($this->arrayCache);
+    }
+
+    public function testWithWrappedCache()
+    {
+        $rootCache = new ArrayAdapter();
+        $wrapped   = DoctrineProvider::wrap($rootCache);
+
+        self::assertSame($rootCache, CacheAdapter::wrap($wrapped));
+    }
+
+    public function testWithWrappedSymfonyCache()
+    {
+        $rootCache = new ArrayAdapter();
+        $wrapped   = new SymfonyDoctrineProvider($rootCache);
+
+        self::assertSame($rootCache, CacheAdapter::wrap($wrapped));
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -11,10 +11,13 @@
 
 namespace Doctrine\Tests\Common\Cache\Psr6;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Tests\Common\Cache\CacheTest;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
 
 use function sprintf;
 
@@ -49,6 +52,22 @@ class DoctrineProviderTest extends CacheTest
         $cache->flushAll();
         $this->assertFalse($cache->fetch($key));
         $this->assertFalse($cache->contains($key));
+    }
+
+    public function testWithWrappedCache()
+    {
+        $rootCache = new ArrayCache();
+        $wrapped   = CacheAdapter::wrap($rootCache);
+
+        self::assertSame($rootCache, DoctrineProvider::wrap($wrapped));
+    }
+
+    public function testWithWrappedSymfonyCache()
+    {
+        $rootCache = new ArrayCache();
+        $wrapped   = new SymfonyDoctrineAdapter($rootCache);
+
+        self::assertSame($rootCache, DoctrineProvider::wrap($wrapped));
     }
 
     public function testGetStats(): void

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -13,15 +13,23 @@ namespace Doctrine\Tests\Common\Cache\Psr6;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
-use PHPUnit\Framework\TestCase;
+use Doctrine\Tests\Common\Cache\CacheTest;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-class DoctrineProviderTest extends TestCase
+use function sprintf;
+
+class DoctrineProviderTest extends CacheTest
 {
+    protected function getCacheDriver(): CacheProvider
+    {
+        $pool = new ArrayAdapter();
+
+        return new DoctrineProvider($pool);
+    }
+
     public function testProvider()
     {
-        $pool  = new ArrayAdapter();
-        $cache = new DoctrineProvider($pool);
+        $cache = $this->getCacheDriver();
 
         $this->assertInstanceOf(CacheProvider::class, $cache);
 
@@ -41,5 +49,15 @@ class DoctrineProviderTest extends TestCase
         $cache->flushAll();
         $this->assertFalse($cache->fetch($key));
         $this->assertFalse($cache->contains($key));
+    }
+
+    public function testGetStats(): void
+    {
+        $this->markTestSkipped(sprintf('"%s" does not expose statistics', DoctrineProvider::class));
+    }
+
+    protected function isSharedStorage(): bool
+    {
+        return false;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -24,7 +24,7 @@ class DoctrineProviderTest extends CacheTest
     {
         $pool = new ArrayAdapter();
 
-        return new DoctrineProvider($pool);
+        return DoctrineProvider::wrap($pool);
     }
 
     public function testProvider()


### PR DESCRIPTION
This PR replaces the public constructors in the PSR-6 compatibility code with factories that unwrap known cache wrappers. This unwraps both our own wrappers as well as the Symfony wrappers. While it's not optimal to expose Symfony internals here, it's better than risking uselessly wrapping caches multiple times, as current versions of our own Symfony bundles for ORM and ODM wrap a PSR-6 cache in a `DoctrineProvider` to inject it for metadata caching etc. @nicolas-grekas let me know if you have any concerns about accessing those private properties here. Thanks!