### PR TITLE
Fix wrong assumption about cache in adapter

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -4,7 +4,9 @@ namespace Doctrine\Common\Cache\Psr6;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\ClearableCache;
-use Doctrine\Common\Cache\MultiOperationCache;
+use Doctrine\Common\Cache\MultiDeleteCache;
+use Doctrine\Common\Cache\MultiGetCache;
+use Doctrine\Common\Cache\MultiPutCache;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\DoctrineProvider as SymfonyDoctrineProvider;
@@ -25,7 +27,7 @@ final class CacheAdapter implements CacheItemPoolInterface
 {
     private const RESERVED_CHARACTERS = '{}()/\@:';
 
-    /** @var Cache|ClearableCache|MultiOperationCache */
+    /** @var Cache */
     private $cache;
 
     /** @var CacheItem[] */
@@ -91,7 +93,7 @@ final class CacheAdapter implements CacheItemPoolInterface
 
         assert(self::validKeys($keys));
 
-        $values = $this->cache->fetchMultiple($keys);
+        $values = $this->doFetchMultiple($keys);
         $items  = [];
         foreach ($keys as $key) {
             if (array_key_exists($key, $values)) {
@@ -122,6 +124,10 @@ final class CacheAdapter implements CacheItemPoolInterface
     {
         $this->deferredItems = [];
 
+        if (! $this->cache instanceof ClearableCache) {
+            return false;
+        }
+
         return $this->cache->deleteAll();
     }
 
@@ -146,7 +152,7 @@ final class CacheAdapter implements CacheItemPoolInterface
             unset($this->deferredItems[$key]);
         }
 
-        return $this->cache->deleteMultiple($keys);
+        return $this->doDeleteMultiple($keys);
     }
 
     public function save(CacheItemInterface $item): bool
@@ -196,7 +202,7 @@ final class CacheAdapter implements CacheItemPoolInterface
                 $this->cache->delete(current($expiredKeys));
                 break;
             default:
-                $this->cache->deleteMultiple($expiredKeys);
+                $this->doDeleteMultiple($expiredKeys);
                 break;
         }
 
@@ -206,7 +212,7 @@ final class CacheAdapter implements CacheItemPoolInterface
 
         $success = true;
         foreach ($byLifetime as $lifetime => $values) {
-            $success = $this->cache->saveMultiple($values, $lifetime) && $success;
+            $success = $this->doSaveMultiple($values, $lifetime) && $success;
         }
 
         return $success;
@@ -247,5 +253,63 @@ final class CacheAdapter implements CacheItemPoolInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param mixed[] $keys
+     */
+    private function doDeleteMultiple(array $keys): bool
+    {
+        if ($this->cache instanceof MultiDeleteCache) {
+            return $this->cache->deleteMultiple($keys);
+        }
+
+        $success = true;
+        foreach ($keys as $key) {
+            $success = $this->cache->delete($key) && $success;
+        }
+
+        return $success;
+    }
+
+    /**
+     * @param mixed[] $keys
+     *
+     * @return mixed[]
+     */
+    private function doFetchMultiple(array $keys): array
+    {
+        if ($this->cache instanceof MultiGetCache) {
+            return $this->cache->fetchMultiple($keys);
+        }
+
+        $values = [];
+        foreach ($keys as $key) {
+            $value = $this->cache->fetch($key);
+            if (! $value) {
+                continue;
+            }
+
+            $values[$key] = $value;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param mixed[] $keysAndValues
+     */
+    private function doSaveMultiple(array $keysAndValues, int $lifetime = 0): bool
+    {
+        if ($this->cache instanceof MultiPutCache) {
+            return $this->cache->saveMultiple($keysAndValues, $lifetime);
+        }
+
+        $success = true;
+        foreach ($keysAndValues as $key => $value) {
+            $success = $this->cache->save($key, $value, $lifetime) && $success;
+        }
+
+        return $success;
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -4,11 +4,16 @@ namespace Doctrine\Tests\Common\Cache\Psr6;
 
 use Cache\IntegrationTests\CachePoolTest;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider as SymfonyDoctrineProvider;
+
+use function array_key_exists;
+use function assert;
 
 final class CacheAdapterTest extends CachePoolTest
 {
@@ -38,5 +43,68 @@ final class CacheAdapterTest extends CachePoolTest
         $wrapped   = new SymfonyDoctrineProvider($rootCache);
 
         self::assertSame($rootCache, CacheAdapter::wrap($wrapped));
+    }
+
+    public function testWithWrappedMinimalCache()
+    {
+        $rootCache = new class implements Cache {
+            /** @var mixed[] */
+            public $values = [];
+
+            /** @inheritdoc **/
+            public function fetch($id)
+            {
+                return $values[$id] ?? false;
+            }
+
+            /** @inheritdoc **/
+            public function contains($id)
+            {
+                return array_key_exists($id, $this->values);
+            }
+
+            /** @inheritdoc **/
+            public function save($id, $data, $lifeTime = 0)
+            {
+                $this->values[$id] = $data;
+
+                return true;
+            }
+
+            /** @inheritdoc **/
+            public function delete($id)
+            {
+                unset($this->values[$id]);
+
+                return true;
+            }
+
+            /** @inheritdoc **/
+            public function getStats()
+            {
+                return null;
+            }
+        };
+
+        $adapter = CacheAdapter::wrap($rootCache);
+        self::assertInstanceOf(CacheAdapter::class, $adapter);
+        assert($adapter instanceof CacheAdapter);
+
+        /** @var CacheItemInterface[] $items */
+        $items = $adapter->getItems(['1', '2', '3']);
+        self::assertCount(3, $items);
+        foreach ($items as $key => $item) {
+            $item->set($key);
+            $adapter->saveDeferred($item);
+        }
+
+        self::assertTrue($adapter->commit());
+        self::assertCount(3, $rootCache->values);
+
+        self::assertFalse($adapter->clear());
+        self::assertCount(3, $rootCache->values);
+
+        self::assertTrue($adapter->deleteItems(['1', '2']));
+        self::assertCount(1, $rootCache->values);
     }
 }


### PR DESCRIPTION
Fixes #369.

The PSR6 `CacheAdapter` class wrongfully assumed that any `Cache` given to it is actually a `CacheProvider` implementing both the `ClearableCache` and `MultiOperationCache` interfaces.

This PR fixes this assumption by emulating the missing behaviour if the given cache does not implement the required interface. In the case of clearing the cache, we return false to indicate that the cache couldn't be cleared. I believe this is inline with the semantics of the interface.