### PR TITLE
CacheAdapter: fix lifetime type

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -201,7 +201,7 @@ final class CacheAdapter implements CacheItemPoolInterface
         }
 
         if ($itemsCount === 1) {
-            return $this->cache->save($key, $item->get(), $lifetime);
+            return $this->cache->save($key, $item->get(), (int) $lifetime);
         }
 
         $success = true;


### PR DESCRIPTION
Lifetime is computed as a difference of two floats (microtime) and then is passed to method annotated as integer. Lifetime is correctly cast to int when multiple items are saved (see L189), but it is not cast when single item is saved.
