### PR TITLE
Make "@return mixed" explicit on CacheItem::get()

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheItem.php
@@ -45,6 +45,8 @@ final class CacheItem implements CacheItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return mixed
      */
     public function get()
     {


### PR DESCRIPTION
This explicit mention tells that the next major will add the return type explicitly.

This will remove a deprecation on the Symfony CI also:
> Method "Psr\Cache\CacheItemInterface::get()" will return "mixed" as of its next major version. Doing the same in implementation "Doctrine\Common\Cache\Psr6\CacheItem" will be required when upgrading.