### PR TITLE
Multiple items manipulation in PSR-6 DoctrineProvider

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -19,8 +19,10 @@ use Traversable;
 
 use function array_combine;
 use function array_filter;
+use function array_flip;
 use function array_keys;
 use function array_map;
+use function array_replace;
 use function iterator_to_array;
 use function rawurlencode;
 
@@ -129,7 +131,7 @@ final class DoctrineProvider extends CacheProvider
      */
     protected function doSaveMultiple(array $keysAndValues, $lifetime = 0): bool
     {
-        $keys = array_keys($keysAndValues);
+        $keys        = array_keys($keysAndValues);
         $encodedKeys = array_map('rawurlencode', $keys);
 
         $items = $this->pool->getItems($encodedKeys);

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -82,9 +82,6 @@ final class DoctrineProvider extends CacheProvider
 
         $result = [];
         foreach ($keys as $key) {
-            // To be checked whether redoing the rawurlencode is slower or faster than using a
-            // single `array_combine` to create a mapping of keys to encoded keys, or comparing
-            // that to building both the list and the map with a loop instead of the array_map
             $item = $items[rawurlencode($key)];
 
             if (! $item->isHit()) {
@@ -134,9 +131,6 @@ final class DoctrineProvider extends CacheProvider
         }
 
         foreach ($keysAndValues as $key => $value) {
-            // To be checked whether redoing the rawurlencode is slower or faster than using a
-            // single `array_combine` to create a mapping of keys to encoded keys, or comparing
-            // that to building both the list and the map with a loop instead of the array_map
             $item = $items[rawurlencode($key)];
 
             if (! $this->pool->saveDeferred($item->set($value))) {

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -78,10 +78,15 @@ final class DoctrineProvider extends CacheProvider
      */
     protected function doFetchMultiple(array $keys): array
     {
-        $items = $this->pool->getItems(array_map('rawurlencode', $keys));
+        $encodedKeys = array_map('rawurlencode', $keys);
+
+        $items = $this->pool->getItems($encodedKeys);
         if ($items instanceof Traversable) {
             $items = iterator_to_array($items);
         }
+
+        // Sorting items by keys
+        $items = array_replace(array_flip($encodedKeys), $items);
 
         $items = array_combine($keys, $items);
         $items = array_filter($items, static function (CacheItemInterface $item) {
@@ -125,11 +130,15 @@ final class DoctrineProvider extends CacheProvider
     protected function doSaveMultiple(array $keysAndValues, $lifetime = 0): bool
     {
         $keys = array_keys($keysAndValues);
+        $encodedKeys = array_map('rawurlencode', $keys);
 
-        $items = $this->pool->getItems(array_map('rawurlencode', $keys));
+        $items = $this->pool->getItems($encodedKeys);
         if ($items instanceof Traversable) {
             $items = iterator_to_array($items);
         }
+
+        // Sorting items by keys
+        $items = array_replace(array_flip($encodedKeys), $items);
 
         $items = array_combine($keys, $items);
         foreach ($items as $key => $item) {

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -19,6 +19,7 @@ use Doctrine\Tests\Common\Cache\CacheTest;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
 
+use function array_keys;
 use function sprintf;
 
 class DoctrineProviderTest extends CacheTest
@@ -52,6 +53,25 @@ class DoctrineProviderTest extends CacheTest
         $cache->flushAll();
         $this->assertFalse($cache->fetch($key));
         $this->assertFalse($cache->contains($key));
+    }
+
+    public function testProviderMultiOperation()
+    {
+        $cache = $this->getCacheDriver();
+
+        $values = [
+            'foo'      => 'bar',
+            '{}()/\@:' => 'baz',
+        ];
+        $keys   = array_keys($values);
+
+        $this->assertTrue($cache->saveMultiple($values));
+        $this->assertSame($values, $cache->fetchMultiple($keys));
+
+        $this->assertTrue($cache->deleteMultiple($keys));
+        foreach ($keys as $key) {
+            $this->assertFalse($cache->contains($key));
+        }
     }
 
     public function testWithWrappedCache()


### PR DESCRIPTION
Hi!

PSR-6 [DoctrineProvider](https://github.com/doctrine/cache/blob/1.11.x/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php) doesn't use methods provided by PSR-6 `CacheItemPoolInterface` for multiple items manipulation, such as `getItems()`, `saveDeferred()`/`commit()` and `deleteItems()`. It may impact performance since base `CacheProvider` implementation of [doFetchMultiple()](https://github.com/doctrine/cache/blob/9c53086695937c50c47936ed86d96150ffbcf60d/lib/Doctrine/Common/Cache/CacheProvider.php#L215:L216)/[doSaveMultiple()](https://github.com/doctrine/cache/blob/9c53086695937c50c47936ed86d96150ffbcf60d/lib/Doctrine/Common/Cache/CacheProvider.php#L258:L259)/[doDeleteMultiple()](https://github.com/doctrine/cache/blob/9c53086695937c50c47936ed86d96150ffbcf60d/lib/Doctrine/Common/Cache/CacheProvider.php#L292:L293) simply converts 1 multiple operation to N single operations.