### PR TITLE
Fix the PSR-6 wrapping for doctrine caches with a namespace

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -37,11 +37,11 @@ final class CacheAdapter implements CacheItemPoolInterface
 
     public static function wrap(Cache $cache): CacheItemPoolInterface
     {
-        if ($cache instanceof DoctrineProvider) {
+        if ($cache instanceof DoctrineProvider && ! $cache->getNamespace()) {
             return $cache->getPool();
         }
 
-        if ($cache instanceof SymfonyDoctrineProvider) {
+        if ($cache instanceof SymfonyDoctrineProvider && ! $cache->getNamespace()) {
             $getPool = function () {
                 // phpcs:ignore Squiz.Scope.StaticThisUsage.Found
                 return $this->pool;

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -127,4 +127,43 @@ final class CacheAdapterTest extends CachePoolTest
         $adapter->commit();
         $adapter->commit();
     }
+
+    public function testNamespacingFeatureIsPreservedWithDoctrineProvider(): void
+    {
+        $wrapped = new ArrayAdapter();
+
+        $cacheApp1 = DoctrineProvider::wrap($wrapped);
+        $cacheApp1->setNamespace('app 1');
+
+        $cacheApp2 = DoctrineProvider::wrap($wrapped);
+        $cacheApp2->setNamespace('app 2');
+
+        $psrCacheApp1 = CacheAdapter::wrap($cacheApp1);
+        $psrCacheApp2 = CacheAdapter::wrap($cacheApp2);
+
+        $item = $psrCacheApp1->getItem('some key')->set('some value');
+        $psrCacheApp1->save($item);
+        self::assertFalse($psrCacheApp2->getItem('some key')->isHit());
+    }
+
+    /**
+     * @requires function Symfony\Component\Cache\DoctrineProvider::__construct
+     */
+    public function testNamespacingFeatureIsPreservedWithSymfonyDoctrineProvider(): void
+    {
+        $wrapped = new ArrayAdapter();
+
+        $cacheApp1 = new SymfonyDoctrineProvider($wrapped);
+        $cacheApp1->setNamespace('app 1');
+
+        $cacheApp2 = new SymfonyDoctrineProvider($wrapped);
+        $cacheApp2->setNamespace('app 2');
+
+        $psrCacheApp1 = CacheAdapter::wrap($cacheApp1);
+        $psrCacheApp2 = CacheAdapter::wrap($cacheApp2);
+
+        $item = $psrCacheApp1->getItem('some key')->set('some value');
+        $psrCacheApp1->save($item);
+        self::assertFalse($psrCacheApp2->getItem('some key')->isHit());
+    }
 }


### PR DESCRIPTION
If a namespace is set in a DoctrineProvider cache, we cannot unwrap the inner PSR-6 cache pool, as that would loose the namespacing feature. We need to add an additional wrapper instead.

Closes #380