### PR TITLE
Allow psr/cache v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
         "predis/predis":   "~1.0",
         "doctrine/coding-standard": "^8.0",
-        "psr/cache": "^1.0 || ^2.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "cache/integration-tests": "dev-master",
-        "symfony/cache": "^4.4 || ^5.2"
+        "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
+        "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
     },
     "conflict": {
-        "doctrine/common": ">2.2,<2.4",
-        "psr/cache": ">=3"
+        "doctrine/common": ">2.2,<2.4"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache" }

--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -23,6 +23,8 @@ use function microtime;
 use function sprintf;
 use function strpbrk;
 
+use const PHP_VERSION_ID;
+
 final class CacheAdapter implements CacheItemPoolInterface
 {
     private const RESERVED_CHARACTERS = '{}()/\@:';
@@ -30,7 +32,7 @@ final class CacheAdapter implements CacheItemPoolInterface
     /** @var Cache */
     private $cache;
 
-    /** @var CacheItem[] */
+    /** @var array<CacheItem|TypedCacheItem> */
     private $deferredItems = [];
 
     public static function wrap(Cache $cache): CacheItemPoolInterface
@@ -75,6 +77,14 @@ final class CacheAdapter implements CacheItemPoolInterface
 
         $value = $this->cache->fetch($key);
 
+        if (PHP_VERSION_ID >= 80000) {
+            if ($value !== false) {
+                return new TypedCacheItem($key, $value, true);
+            }
+
+            return new TypedCacheItem($key, null, false);
+        }
+
         if ($value !== false) {
             return new CacheItem($key, $value, true);
         }
@@ -95,6 +105,19 @@ final class CacheAdapter implements CacheItemPoolInterface
 
         $values = $this->doFetchMultiple($keys);
         $items  = [];
+
+        if (PHP_VERSION_ID >= 80000) {
+            foreach ($keys as $key) {
+                if (array_key_exists($key, $values)) {
+                    $items[$key] = new TypedCacheItem($key, $values[$key], true);
+                } else {
+                    $items[$key] = new TypedCacheItem($key, null, false);
+                }
+            }
+
+            return $items;
+        }
+
         foreach ($keys as $key) {
             if (array_key_exists($key, $values)) {
                 $items[$key] = new CacheItem($key, $values[$key], true);
@@ -162,7 +185,7 @@ final class CacheAdapter implements CacheItemPoolInterface
 
     public function saveDeferred(CacheItemInterface $item): bool
     {
-        if (! $item instanceof CacheItem) {
+        if (! $item instanceof CacheItem && ! $item instanceof TypedCacheItem) {
             return false;
         }
 

--- a/lib/Doctrine/Common/Cache/Psr6/TypedCacheItem.php
+++ b/lib/Doctrine/Common/Cache/Psr6/TypedCacheItem.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6;
+
+use DateInterval;
+use DateTime;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+use TypeError;
+
+use function get_class;
+use function gettype;
+use function is_int;
+use function is_object;
+use function microtime;
+use function sprintf;
+
+final class TypedCacheItem implements CacheItemInterface
+{
+    /** @var string */
+    private $key;
+    /** @var mixed */
+    private $value;
+    /** @var bool */
+    private $isHit;
+    /** @var float|null */
+    private $expiry;
+
+    /**
+     * @internal
+     */
+    public function __construct(string $key, mixed $data, bool $isHit)
+    {
+        $this->key   = $key;
+        $this->value = $data;
+        $this->isHit = $isHit;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->isHit;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set($value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function expiresAt($expiration): static
+    {
+        if ($expiration === null) {
+            $this->expiry = null;
+        } elseif ($expiration instanceof DateTimeInterface) {
+            $this->expiry = (float) $expiration->format('U.u');
+        } else {
+            throw new TypeError(sprintf(
+                'Expected $expiration to be an instance of DateTimeInterface or null, got %s',
+                is_object($expiration) ? get_class($expiration) : gettype($expiration)
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function expiresAfter($time): static
+    {
+        if ($time === null) {
+            $this->expiry = null;
+        } elseif ($time instanceof DateInterval) {
+            $this->expiry = microtime(true) + DateTime::createFromFormat('U', 0)->add($time)->format('U.u');
+        } elseif (is_int($time)) {
+            $this->expiry = $time + microtime(true);
+        } else {
+            throw new TypeError(sprintf(
+                'Expected $time to be either an integer, an instance of DateInterval or null, got %s',
+                is_object($time) ? get_class($time) : gettype($time)
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function getExpiry(): ?float
+    {
+        return $this->expiry;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -37,6 +37,9 @@ final class CacheAdapterTest extends CachePoolTest
         self::assertSame($rootCache, CacheAdapter::wrap($wrapped));
     }
 
+    /**
+     * @requires function Symfony\Component\Cache\DoctrineProvider::__construct
+     */
     public function testWithWrappedSymfonyCache()
     {
         $rootCache = new ArrayAdapter();


### PR DESCRIPTION
Although this lib is deprecated, it's going to fade away quite slowly I suppose.
Having it conflict with `"psr/cache": ">=3"` is going to block the adoption of the newer versions of the PSR.

This PR removes this conflict by adding a new `TypedCacheItem` class, since `CacheItem` is the only one that cannot be made compatible with psr/cache v3 without a BC break.

This PR also adds support for symfony/cache v6.