### PR TITLE
Flush deferred items array on commit

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
+++ b/lib/Doctrine/Common/Cache/Psr6/CacheAdapter.php
@@ -218,6 +218,8 @@ final class CacheAdapter implements CacheItemPoolInterface
             $byLifetime[(int) $lifetime][$key] = $item->get();
         }
 
+        $this->deferredItems = [];
+
         switch (count($expiredKeys)) {
             case 0:
                 break;

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/CacheAdapterTest.php
@@ -110,4 +110,21 @@ final class CacheAdapterTest extends CachePoolTest
         self::assertTrue($adapter->deleteItems(['1', '2']));
         self::assertCount(1, $rootCache->values);
     }
+
+    public function testItemsAreFlushedToTheUnderlyingCacheOnce(): void
+    {
+        $wrapped = $this->createMock(Cache::class);
+
+        $adapter   = CacheAdapter::wrap($wrapped);
+        $cacheItem = $adapter->getItem('answer-to-life-universe-everything');
+        $cacheItem->set(42);
+        $adapter->saveDeferred($cacheItem);
+
+        $wrapped->expects(self::once())
+            ->method('save')
+            ->willReturn(true);
+
+        $adapter->commit();
+        $adapter->commit();
+    }
 }


### PR DESCRIPTION
Once the items have been flushed to the wrapped cache, they should be
removed from the internal buffer so that:
- they are not flushed again on subsequent calls to commit()
- the memory they take is freed.

Fixes #386

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/cache-1
composer require doctrine/cache "dev-plug-memory-leak as 1.12.0"
```
or

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/cache-1
composer require doctrine/cache "dev-plug-memory-leak as 2.1.0"
```

depending on what you are currently using.