### PR TITLE
Update branch metadata to reflect current state

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,20 +5,38 @@
     "docsSlug": "doctrine-cache",
     "versions": [
         {
+            "name": "2.1",
+            "branchName": "2.1.x",
+            "slug": "2.1",
+            "current": true
+        },
+        {
+            "name": "2.0",
+            "branchName": "2.0.x",
+            "slug": "2.0",
+            "maintained": false
+        },
+        {
+            "name": "1.12",
+            "branchName": "1.12.x",
+            "slug": "1.12",
+            "maintained": true
+        },
+        {
             "name": "1.11",
             "branchName": "1.11.x",
-            "slug": "latest",
-            "upcoming": true
+            "slug": "1.11",
+            "maintained": false
         },
         {
             "name": "1.10",
             "branchName": "1.10.x",
             "slug": "1.10",
-            "current": true
+            "maintained": false
         },
         {
             "name": "1.9",
-            "branchName": "1.8.x",
+            "branchName": "1.9.x",
             "slug": "1.9",
             "maintained": false
         },


### PR DESCRIPTION
The 1.x series is not maintained anymore. Also, there should not be a
2.2.x.