### PR TITLE
Add reset() to PSR-6 DoctrineProvider

### DIFF
--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -129,6 +129,7 @@ final class DoctrineProvider extends CacheProvider
         if ($this->pool instanceof ResetInterface) {
             $this->pool->reset();
         }
+
         $this->setNamespace($this->getNamespace());
     }
 }

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -58,6 +58,15 @@ final class DoctrineProvider extends CacheProvider
         return $this->pool;
     }
 
+    public function reset(): void
+    {
+        if ($this->pool instanceof ResetInterface) {
+            $this->pool->reset();
+        }
+
+        $this->setNamespace($this->getNamespace());
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -122,14 +131,5 @@ final class DoctrineProvider extends CacheProvider
     protected function doGetStats()
     {
         return null;
-    }
-
-    public function reset(): void
-    {
-        if ($this->pool instanceof ResetInterface) {
-            $this->pool->reset();
-        }
-
-        $this->setNamespace($this->getNamespace());
     }
 }

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -124,7 +124,7 @@ final class DoctrineProvider extends CacheProvider
         return null;
     }
 
-    public function reset()
+    public function reset(): void
     {
         if ($this->pool instanceof ResetInterface) {
             $this->pool->reset();

--- a/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
+++ b/lib/Doctrine/Common/Cache/Psr6/DoctrineProvider.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
+use Symfony\Contracts\Service\ResetInterface;
 
 use function rawurlencode;
 
@@ -121,5 +122,13 @@ final class DoctrineProvider extends CacheProvider
     protected function doGetStats()
     {
         return null;
+    }
+
+    public function reset()
+    {
+        if ($this->pool instanceof ResetInterface) {
+            $this->pool->reset();
+        }
+        $this->setNamespace($this->getNamespace());
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -18,10 +18,11 @@ use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Tests\Common\Cache\CacheTest;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
-
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
 use function class_exists;
 use function sprintf;
+use function sys_get_temp_dir;
 
 class DoctrineProviderTest extends CacheTest
 {
@@ -94,9 +95,9 @@ class DoctrineProviderTest extends CacheTest
 
     public function testResetFilesystemAdapter()
     {
-        $pool = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
-        $pool2 = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
-        $cache = DoctrineProvider::wrap($pool);
+        $pool   = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
+        $pool2  = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
+        $cache  = DoctrineProvider::wrap($pool);
         $cache2 = DoctrineProvider::wrap($pool2);
 
         $cache->save('test', 'test');

--- a/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/Psr6/DoctrineProviderTest.php
@@ -19,6 +19,7 @@ use Doctrine\Tests\Common\Cache\CacheTest;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter as SymfonyDoctrineAdapter;
 
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use function class_exists;
 use function sprintf;
 
@@ -78,6 +79,42 @@ class DoctrineProviderTest extends CacheTest
     public function testGetStats(): void
     {
         $this->markTestSkipped(sprintf('"%s" does not expose statistics', DoctrineProvider::class));
+    }
+
+    public function testResetArrayAdapter()
+    {
+        $cache = $this->getCacheDriver();
+
+        $cache->save('test', 'test');
+
+        $cache->reset();
+
+        $this->assertSame(false, $cache->fetch('test'));
+    }
+
+    public function testResetFilesystemAdapter()
+    {
+        $pool = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
+        $pool2 = new FilesystemAdapter('', 0, sys_get_temp_dir() . '/doctrine-cache-test');
+        $cache = DoctrineProvider::wrap($pool);
+        $cache2 = DoctrineProvider::wrap($pool2);
+
+        $cache->save('test', 'test');
+        $cache->reset();
+
+        // we make sure with the next assertion the cache behave like expected and the test is not accidentally changed
+        // to use ArrayAdapter as this test scenario requires a persisted cache adapter
+        $this->assertSame('test', $cache->fetch('test'));
+
+        // the second cache instance will now remove all exist files via namespaceVersion still the first cache
+        // will receive the data until then the reset is called. the assertion after deleteAll is not required
+        // but better show why the reset is even needed when cache service is used in long-running processes.
+        $cache2->deleteAll();
+        $this->assertSame('test', $cache->fetch('test'));
+        $cache->reset();
+
+        // the previous called reset will reset the namespaceVersion and so the cache is correctly false now
+        $this->assertSame(false, $cache->fetch('test'));
     }
 
     protected function isSharedStorage(): bool


### PR DESCRIPTION
When using a symfony application which run on swoole or roadrunner the services need to be resetted between the runs. Same for messenger:consume command services are resetted and require this call.

We did stumble else over problems with the caches and needed to add the `kernel.reset` tag to the doctrine caches: https://github.com/sulu/skeleton/pull/141/files

The reset method was implemented here and also reseted the Namespace correctly:

https://github.com/symfony/cache/blob/4c6747cf7e56c6b8e3094dd24852bd3e364375b1/DoctrineProvider.php#L49-L55

This seems not to be added when moved the DoctrineProvider from Symfony/Cache to this repository: https://github.com/doctrine/cache/pull/366

Symfony itself added the reset in this pull request. https://github.com/symfony/symfony/pull/24226. Maybe @nicolas-grekas can also gave insights about the get set Namespace here.