### PR TITLE
Run CI tests every week

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - "*.x"
+  schedule:
+      - cron: "0 0 * * 0"
 
 env:
   fail-fast: true


### PR DESCRIPTION
If creating a pull request like [here](https://github.com/doctrine/cache/pull/398). It is always nice to know if the tests did run on the target branch. In a repository which does not have a lot of changes it is maybe nice to run atleast once a week the tests via a cron.