### PR TITLE
Disable fail-fast

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: "ubuntu-20.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.1"


### PR DESCRIPTION
The CI is red at the moment and given that we don't update this package that often anymore, this might happen from time to time. I'd like to see all failures and not just those of the job that failed first.