### PR TITLE
Remove obsolete dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,20 +28,6 @@ jobs:
           - "8.0"
           - "8.1"
 
-    services:
-      mongodb:
-        image: "mongo:4.4"
-        ports:
-          - "27017:27017"
-      redis:
-        image: "redis:6.0.9"
-        ports:
-          - "6379:6379"
-      memcached:
-        image: "memcached:1.6.9"
-        ports:
-          - "11211:11211"
-
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -54,8 +40,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "xdebug"
-          extensions: "apcu, mongodb-4.4, memcached"
-          ini-values: "zend.assertions=1, apc.enable_cli=1"
+          ini-values: "zend.assertions=1"
 
       - name: "Install PHP with PCOV"
         uses: "shivammathur/setup-php@v2"
@@ -63,8 +48,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          extensions: "apcu, mongodb-4.4, memcached"
-          ini-values: "zend.assertions=1, apc.enable_cli=1"
+          ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,12 @@
         "php": "~7.1 || ^8.0"
     },
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.1",
-        "mongodb/mongodb": "^1.1",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-        "predis/predis":   "~1.0",
         "doctrine/coding-standard": "^9",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "cache/integration-tests": "dev-master",
         "symfony/cache": "^4.4 || ^5.4 || ^6",
         "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
-    },
-    "suggest": {
-        "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
     },
     "conflict": {
         "doctrine/common": ">2.2,<2.4"


### PR DESCRIPTION
The 2.1 branch does not contain any cache adapters anymore, just wrappers. Let's remove all those dev dependencies that we don't use anymore.