### PR TITLE
PHP 8.2 CI Support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,6 +27,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Hello,

This PR adds PHP 8.2 as part of CI tests.