### PR TITLE
Add Qlty code coverage integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,13 @@ jobs:
           name: "phpunit-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
+      - name: "Upload coverage to Qlty"
+        if: "${{ matrix.php-version == '8.3' }}"
+        uses: "qltysh/qlty-action/coverage@v2"
+        with:
+          token: "${{ secrets.QLTY_COVERAGE_TOKEN }}"
+          files: "coverage.xml"
+
   upload_coverage:
     name: "Upload coverage to Codecov"
     runs-on: "ubuntu-22.04"


### PR DESCRIPTION
## Summary

- Adds Qlty Cloud coverage upload to the CI workflow using the official GitHub Action (`qltysh/qlty-action/coverage@v2`)
- Uploads PHPUnit Clover XML coverage data from the PHP 8.3 matrix job only (all PHP versions produce equivalent coverage)
- Uses token-based authentication (`QLTY_COVERAGE_TOKEN` secret)
- Existing Codecov upload is preserved unchanged

## Manual steps required

1. **Add the `QLTY_COVERAGE_TOKEN` secret** to the repository:
   - Go to Qlty Cloud → Workspace Settings → Code Coverage → copy the coverage token
   - Go to GitHub repo → Settings → Secrets and variables → Actions → New repository secret
   - Name: `QLTY_COVERAGE_TOKEN`, Value: the token from Qlty

## Test plan

- [ ] Verify CI workflow runs successfully on this PR
- [ ] Verify Qlty coverage upload step completes with coverage data published
- [ ] Verify coverage appears in Qlty Cloud dashboard after merging to default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)